### PR TITLE
Fix npe exception

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -199,7 +199,7 @@ const Decorator = {
 
     const textEditor = Utils.document.getEditors ( doc )[0];
 
-    if ( Decorator.docsLines[textEditor['id']] === doc.lineCount ) {
+    if ( textEditor && Decorator.docsLines[textEditor['id']] === doc.lineCount ) {
 
       const decorations = Decorator.decorations[textEditor['id']];
 


### PR DESCRIPTION
Fixes #25

I think it should be enough (other uses of `textEditor['id']` look guarded against exceptions).