### PR TITLE
Configuration schema and generate/update scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Highlight",
   "description": "Advanced text highlighter based on regexes. Useful for todos, annotations, colors etc.",
   "icon": "resources/logo-128x128.png",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "main": "out/extension.js",
   "publisher": "fabiospampinato",
@@ -20,16 +20,2072 @@
           "description": "Default decorations from which all others inherit from",
           "default": {
             "rangeBehavior": 3
+          },
+          "properties": {
+            "after": {
+              "type": "object",
+              "default": {},
+              "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+              "properties": {
+                "backgroundColor": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "border": {
+                  "default": "",
+                  "type": "string"
+                },
+                "borderColor": {
+                  "default": "#FFFFFF22",
+                  "format": "color",
+                  "type": "string"
+                },
+                "color": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "contentIconPath": {
+                  "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                  "oneOf": [
+                    {
+                      "default": "",
+                      "format": "uri",
+                      "type": "string"
+                    },
+                    {
+                      "default": "",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "contentText": {
+                  "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                  "default": "",
+                  "type": "string"
+                },
+                "fontStyle": {
+                  "default": "",
+                  "enum": [
+                    "normal",
+                    "italic",
+                    "oblique",
+                    ""
+                  ],
+                  "type": "string"
+                },
+                "fontWeight": {
+                  "enum": [
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    "bold",
+                    "medium"
+                  ],
+                  "type": "string",
+                  "default": "500"
+                },
+                "height": {
+                  "type": "string",
+                  "default": ""
+                },
+                "margin": {
+                  "type": "string",
+                  "default": ""
+                },
+                "textDecoration": {
+                  "default": "",
+                  "type": "string",
+                  "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                },
+                "width": {
+                  "default": "",
+                  "type": "string"
+                }
+              }
+            },
+            "backgroundColor": {
+              "default": "",
+              "format": "color",
+              "type": "string"
+            },
+            "before": {
+              "type": "object",
+              "default": {},
+              "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+              "properties": {
+                "backgroundColor": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "border": {
+                  "default": "",
+                  "type": "string"
+                },
+                "borderColor": {
+                  "default": "#FFFFFF22",
+                  "format": "color",
+                  "type": "string"
+                },
+                "color": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "contentIconPath": {
+                  "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                  "oneOf": [
+                    {
+                      "default": "",
+                      "format": "uri",
+                      "type": "string"
+                    },
+                    {
+                      "default": "",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "contentText": {
+                  "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                  "default": "",
+                  "type": "string"
+                },
+                "fontStyle": {
+                  "default": "",
+                  "enum": [
+                    "normal",
+                    "italic",
+                    "oblique",
+                    ""
+                  ],
+                  "type": "string"
+                },
+                "fontWeight": {
+                  "enum": [
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    "bold",
+                    "medium"
+                  ],
+                  "type": "string",
+                  "default": "500"
+                },
+                "height": {
+                  "type": "string",
+                  "default": ""
+                },
+                "margin": {
+                  "type": "string",
+                  "default": ""
+                },
+                "textDecoration": {
+                  "default": "",
+                  "type": "string",
+                  "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                },
+                "width": {
+                  "default": "",
+                  "type": "string"
+                }
+              }
+            },
+            "border": {
+              "default": "",
+              "type": "string"
+            },
+            "borderColor": {
+              "default": "#FFFFFF22",
+              "format": "color",
+              "type": "string"
+            },
+            "borderRadius": {
+              "default": "4px",
+              "examples": [
+                "2px",
+                "0.25em",
+                "2px 0px",
+                "0px 0px 0px 4px",
+                "10px 40px / 20px 60px"
+              ],
+              "type": "string"
+            },
+            "borderSpacing": {
+              "default": "2px",
+              "type": "string"
+            },
+            "borderStyle": {
+              "enum": [
+                "solid",
+                "dotted",
+                "dashed"
+              ],
+              "type": "string",
+              "default": ""
+            },
+            "borderWidth": {
+              "type": "string",
+              "default": ""
+            },
+            "color": {
+              "default": "",
+              "format": "color",
+              "type": "string"
+            },
+            "contentIconPath": {
+              "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+              "oneOf": [
+                {
+                  "default": "",
+                  "format": "uri",
+                  "type": "string"
+                },
+                {
+                  "default": "",
+                  "type": "string"
+                }
+              ]
+            },
+            "contentText": {
+              "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+              "default": "",
+              "type": "string"
+            },
+            "cursor": {
+              "default": "",
+              "type": "string"
+            },
+            "dark": {
+              "type": "object",
+              "description": "Overwrite options for dark themes.",
+              "default": {},
+              "properties": {
+                "after": {
+                  "type": "object",
+                  "default": {},
+                  "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                  "properties": {
+                    "backgroundColor": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "border": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "borderColor": {
+                      "default": "#FFFFFF22",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "color": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "contentIconPath": {
+                      "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                      "oneOf": [
+                        {
+                          "default": "",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        {
+                          "default": "",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "contentText": {
+                      "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                      "default": "",
+                      "type": "string"
+                    },
+                    "fontStyle": {
+                      "default": "",
+                      "enum": [
+                        "normal",
+                        "italic",
+                        "oblique",
+                        ""
+                      ],
+                      "type": "string"
+                    },
+                    "fontWeight": {
+                      "enum": [
+                        "100",
+                        "200",
+                        "300",
+                        "400",
+                        "500",
+                        "600",
+                        "700",
+                        "800",
+                        "900",
+                        "bold",
+                        "medium"
+                      ],
+                      "type": "string",
+                      "default": "500"
+                    },
+                    "height": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "margin": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "textDecoration": {
+                      "default": "",
+                      "type": "string",
+                      "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                    },
+                    "width": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  }
+                },
+                "backgroundColor": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "before": {
+                  "type": "object",
+                  "default": {},
+                  "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                  "properties": {
+                    "backgroundColor": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "border": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "borderColor": {
+                      "default": "#FFFFFF22",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "color": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "contentIconPath": {
+                      "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                      "oneOf": [
+                        {
+                          "default": "",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        {
+                          "default": "",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "contentText": {
+                      "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                      "default": "",
+                      "type": "string"
+                    },
+                    "fontStyle": {
+                      "default": "",
+                      "enum": [
+                        "normal",
+                        "italic",
+                        "oblique",
+                        ""
+                      ],
+                      "type": "string"
+                    },
+                    "fontWeight": {
+                      "enum": [
+                        "100",
+                        "200",
+                        "300",
+                        "400",
+                        "500",
+                        "600",
+                        "700",
+                        "800",
+                        "900",
+                        "bold",
+                        "medium"
+                      ],
+                      "type": "string",
+                      "default": "500"
+                    },
+                    "height": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "margin": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "textDecoration": {
+                      "default": "",
+                      "type": "string",
+                      "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                    },
+                    "width": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  }
+                },
+                "border": {
+                  "default": "",
+                  "type": "string"
+                },
+                "borderColor": {
+                  "default": "#FFFFFF22",
+                  "format": "color",
+                  "type": "string"
+                },
+                "borderRadius": {
+                  "default": "4px",
+                  "examples": [
+                    "2px",
+                    "0.25em",
+                    "2px 0px",
+                    "0px 0px 0px 4px",
+                    "10px 40px / 20px 60px"
+                  ],
+                  "type": "string"
+                },
+                "borderSpacing": {
+                  "default": "2px",
+                  "type": "string"
+                },
+                "borderStyle": {
+                  "enum": [
+                    "solid",
+                    "dotted",
+                    "dashed"
+                  ],
+                  "type": "string",
+                  "default": ""
+                },
+                "borderWidth": {
+                  "type": "string",
+                  "default": ""
+                },
+                "color": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "cursor": {
+                  "default": "",
+                  "type": "string"
+                },
+                "fontStyle": {
+                  "default": "",
+                  "enum": [
+                    "normal",
+                    "italic",
+                    "oblique",
+                    ""
+                  ],
+                  "type": "string"
+                },
+                "fontWeight": {
+                  "enum": [
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    "bold",
+                    "medium"
+                  ],
+                  "type": "string",
+                  "default": "500"
+                },
+                "gutterIconPath": {
+                  "type": "string",
+                  "default": "",
+                  "format": "uri",
+                  "description": "An absolute path or an URI to an image to be rendered in the gutter."
+                },
+                "gutterIconSize": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+                  "oneOf": [
+                    {
+                      "pattern": "\\d+(\\.\\d+)%"
+                    },
+                    {
+                      "enum": [
+                        "auto",
+                        "contain",
+                        "cover"
+                      ]
+                    }
+                  ]
+                },
+                "letterSpacing": {
+                  "type": "string",
+                  "default": ""
+                },
+                "opacity": {
+                  "type": "string",
+                  "default": ""
+                },
+                "outline": {
+                  "type": "string",
+                  "default": ""
+                },
+                "outlineColor": {
+                  "type": "string",
+                  "default": "",
+                  "format": "color",
+                  "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                },
+                "outlineStyle": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                },
+                "outlineWidth": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                },
+                "overviewRulerColor": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string",
+                  "description": "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
+                },
+                "textDecoration": {
+                  "default": "",
+                  "type": "string",
+                  "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                }
+              }
+            },
+            "fontStyle": {
+              "default": "",
+              "enum": [
+                "normal",
+                "italic",
+                "oblique",
+                ""
+              ],
+              "type": "string"
+            },
+            "fontWeight": {
+              "enum": [
+                "100",
+                "200",
+                "300",
+                "400",
+                "500",
+                "600",
+                "700",
+                "800",
+                "900",
+                "bold",
+                "medium"
+              ],
+              "type": "string",
+              "default": "500"
+            },
+            "gutterIconPath": {
+              "type": "string",
+              "default": "",
+              "format": "uri",
+              "description": "An absolute path or an URI to an image to be rendered in the gutter."
+            },
+            "gutterIconSize": {
+              "type": "string",
+              "default": "",
+              "description": "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+              "oneOf": [
+                {
+                  "pattern": "\\d+(\\.\\d+)%"
+                },
+                {
+                  "enum": [
+                    "auto",
+                    "contain",
+                    "cover"
+                  ]
+                }
+              ]
+            },
+            "isWholeLine": {
+              "type": "boolean",
+              "default": false,
+              "description": "Should the decoration be rendered also on the whitespace after the line text."
+            },
+            "letterSpacing": {
+              "type": "string",
+              "default": ""
+            },
+            "light": {
+              "type": "object",
+              "description": "Overwrite options for light themes.",
+              "default": {},
+              "properties": {
+                "after": {
+                  "type": "object",
+                  "default": {},
+                  "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                  "properties": {
+                    "backgroundColor": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "border": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "borderColor": {
+                      "default": "#FFFFFF22",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "color": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "contentIconPath": {
+                      "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                      "oneOf": [
+                        {
+                          "default": "",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        {
+                          "default": "",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "contentText": {
+                      "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                      "default": "",
+                      "type": "string"
+                    },
+                    "fontStyle": {
+                      "default": "",
+                      "enum": [
+                        "normal",
+                        "italic",
+                        "oblique",
+                        ""
+                      ],
+                      "type": "string"
+                    },
+                    "fontWeight": {
+                      "enum": [
+                        "100",
+                        "200",
+                        "300",
+                        "400",
+                        "500",
+                        "600",
+                        "700",
+                        "800",
+                        "900",
+                        "bold",
+                        "medium"
+                      ],
+                      "type": "string",
+                      "default": "500"
+                    },
+                    "height": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "margin": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "textDecoration": {
+                      "default": "",
+                      "type": "string",
+                      "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                    },
+                    "width": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  }
+                },
+                "backgroundColor": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "before": {
+                  "type": "object",
+                  "default": {},
+                  "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                  "properties": {
+                    "backgroundColor": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "border": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "borderColor": {
+                      "default": "#FFFFFF22",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "color": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "contentIconPath": {
+                      "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                      "oneOf": [
+                        {
+                          "default": "",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        {
+                          "default": "",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "contentText": {
+                      "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                      "default": "",
+                      "type": "string"
+                    },
+                    "fontStyle": {
+                      "default": "",
+                      "enum": [
+                        "normal",
+                        "italic",
+                        "oblique",
+                        ""
+                      ],
+                      "type": "string"
+                    },
+                    "fontWeight": {
+                      "enum": [
+                        "100",
+                        "200",
+                        "300",
+                        "400",
+                        "500",
+                        "600",
+                        "700",
+                        "800",
+                        "900",
+                        "bold",
+                        "medium"
+                      ],
+                      "type": "string",
+                      "default": "500"
+                    },
+                    "height": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "margin": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "textDecoration": {
+                      "default": "",
+                      "type": "string",
+                      "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                    },
+                    "width": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  }
+                },
+                "border": {
+                  "default": "",
+                  "type": "string"
+                },
+                "borderColor": {
+                  "default": "#FFFFFF22",
+                  "format": "color",
+                  "type": "string"
+                },
+                "borderRadius": {
+                  "default": "4px",
+                  "examples": [
+                    "2px",
+                    "0.25em",
+                    "2px 0px",
+                    "0px 0px 0px 4px",
+                    "10px 40px / 20px 60px"
+                  ],
+                  "type": "string"
+                },
+                "borderSpacing": {
+                  "default": "2px",
+                  "type": "string"
+                },
+                "borderStyle": {
+                  "enum": [
+                    "solid",
+                    "dotted",
+                    "dashed"
+                  ],
+                  "type": "string",
+                  "default": ""
+                },
+                "borderWidth": {
+                  "type": "string",
+                  "default": ""
+                },
+                "color": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string"
+                },
+                "cursor": {
+                  "default": "",
+                  "type": "string"
+                },
+                "fontStyle": {
+                  "default": "",
+                  "enum": [
+                    "normal",
+                    "italic",
+                    "oblique",
+                    ""
+                  ],
+                  "type": "string"
+                },
+                "fontWeight": {
+                  "enum": [
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    "bold",
+                    "medium"
+                  ],
+                  "type": "string",
+                  "default": "500"
+                },
+                "gutterIconPath": {
+                  "type": "string",
+                  "default": "",
+                  "format": "uri",
+                  "description": "An absolute path or an URI to an image to be rendered in the gutter."
+                },
+                "gutterIconSize": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+                  "oneOf": [
+                    {
+                      "pattern": "\\d+(\\.\\d+)%"
+                    },
+                    {
+                      "enum": [
+                        "auto",
+                        "contain",
+                        "cover"
+                      ]
+                    }
+                  ]
+                },
+                "letterSpacing": {
+                  "type": "string",
+                  "default": ""
+                },
+                "opacity": {
+                  "type": "string",
+                  "default": ""
+                },
+                "outline": {
+                  "type": "string",
+                  "default": ""
+                },
+                "outlineColor": {
+                  "type": "string",
+                  "default": "",
+                  "format": "color",
+                  "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                },
+                "outlineStyle": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                },
+                "outlineWidth": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                },
+                "overviewRulerColor": {
+                  "default": "",
+                  "format": "color",
+                  "type": "string",
+                  "description": "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
+                },
+                "textDecoration": {
+                  "default": "",
+                  "type": "string",
+                  "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                }
+              }
+            },
+            "opacity": {
+              "type": "string",
+              "default": ""
+            },
+            "outline": {
+              "type": "string",
+              "default": ""
+            },
+            "outlineColor": {
+              "type": "string",
+              "default": "",
+              "format": "color",
+              "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+            },
+            "outlineStyle": {
+              "type": "string",
+              "default": "",
+              "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+            },
+            "outlineWidth": {
+              "type": "string",
+              "default": "",
+              "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+            },
+            "overviewRulerColor": {
+              "default": "",
+              "format": "color",
+              "type": "string",
+              "description": "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
+            },
+            "overviewRulerLane": {
+              "description": "The position in the overview ruler where the decoration should be rendered.",
+              "enum": [
+                "center",
+                "full",
+                "left",
+                "right"
+              ],
+              "type": "string",
+              "default": "center"
+            },
+            "rangeBehavior": {
+              "enum": [
+                1,
+                2,
+                3,
+                4
+              ],
+              "type": "number",
+              "default": 3,
+              "description": "Customize the growing behavior of the decoration when edits occur at the edges of the decoration's range."
+            },
+            "textDecoration": {
+              "default": "",
+              "type": "string",
+              "description": "CSS styling property that will be applied to text enclosed by a decoration."
+            }
           }
         },
         "highlight.regexes": {
           "type": "object",
           "description": "Object mapping regexes to an array of decorations to apply to the capturing groups",
-          "default": {}
+          "default": {},
+          "additionalProperties": {
+            "properties": {
+              "filterFileRegex": {
+                "type": "string"
+              },
+              "filterLanguageRegex": {
+                "type": "string"
+              },
+              "regexFlags": {
+                "type": "string",
+                "description": "Flags used when building the regexes",
+                "pattern": "^((?:([gmi])(?!.*\\2))*)$",
+                "default": "gi"
+              },
+              "decorations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "after": {
+                      "type": "object",
+                      "default": {},
+                      "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                      "properties": {
+                        "backgroundColor": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "border": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "borderColor": {
+                          "default": "#FFFFFF22",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "color": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "contentIconPath": {
+                          "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                          "oneOf": [
+                            {
+                              "default": "",
+                              "format": "uri",
+                              "type": "string"
+                            },
+                            {
+                              "default": "",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "contentText": {
+                          "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                          "default": "",
+                          "type": "string"
+                        },
+                        "fontStyle": {
+                          "default": "",
+                          "enum": [
+                            "normal",
+                            "italic",
+                            "oblique",
+                            ""
+                          ],
+                          "type": "string"
+                        },
+                        "fontWeight": {
+                          "enum": [
+                            "100",
+                            "200",
+                            "300",
+                            "400",
+                            "500",
+                            "600",
+                            "700",
+                            "800",
+                            "900",
+                            "bold",
+                            "medium"
+                          ],
+                          "type": "string",
+                          "default": "500"
+                        },
+                        "height": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "margin": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "textDecoration": {
+                          "default": "",
+                          "type": "string",
+                          "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                        },
+                        "width": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "backgroundColor": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "before": {
+                      "type": "object",
+                      "default": {},
+                      "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                      "properties": {
+                        "backgroundColor": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "border": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "borderColor": {
+                          "default": "#FFFFFF22",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "color": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "contentIconPath": {
+                          "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                          "oneOf": [
+                            {
+                              "default": "",
+                              "format": "uri",
+                              "type": "string"
+                            },
+                            {
+                              "default": "",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "contentText": {
+                          "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                          "default": "",
+                          "type": "string"
+                        },
+                        "fontStyle": {
+                          "default": "",
+                          "enum": [
+                            "normal",
+                            "italic",
+                            "oblique",
+                            ""
+                          ],
+                          "type": "string"
+                        },
+                        "fontWeight": {
+                          "enum": [
+                            "100",
+                            "200",
+                            "300",
+                            "400",
+                            "500",
+                            "600",
+                            "700",
+                            "800",
+                            "900",
+                            "bold",
+                            "medium"
+                          ],
+                          "type": "string",
+                          "default": "500"
+                        },
+                        "height": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "margin": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "textDecoration": {
+                          "default": "",
+                          "type": "string",
+                          "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                        },
+                        "width": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "border": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "borderColor": {
+                      "default": "#FFFFFF22",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "borderRadius": {
+                      "default": "4px",
+                      "examples": [
+                        "2px",
+                        "0.25em",
+                        "2px 0px",
+                        "0px 0px 0px 4px",
+                        "10px 40px / 20px 60px"
+                      ],
+                      "type": "string"
+                    },
+                    "borderSpacing": {
+                      "default": "2px",
+                      "type": "string"
+                    },
+                    "borderStyle": {
+                      "enum": [
+                        "solid",
+                        "dotted",
+                        "dashed"
+                      ],
+                      "type": "string",
+                      "default": ""
+                    },
+                    "borderWidth": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "color": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string"
+                    },
+                    "contentIconPath": {
+                      "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                      "oneOf": [
+                        {
+                          "default": "",
+                          "format": "uri",
+                          "type": "string"
+                        },
+                        {
+                          "default": "",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "contentText": {
+                      "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                      "default": "",
+                      "type": "string"
+                    },
+                    "cursor": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "dark": {
+                      "type": "object",
+                      "description": "Overwrite options for dark themes.",
+                      "default": {},
+                      "properties": {
+                        "after": {
+                          "type": "object",
+                          "default": {},
+                          "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                          "properties": {
+                            "backgroundColor": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "border": {
+                              "default": "",
+                              "type": "string"
+                            },
+                            "borderColor": {
+                              "default": "#FFFFFF22",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "color": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "contentIconPath": {
+                              "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                              "oneOf": [
+                                {
+                                  "default": "",
+                                  "format": "uri",
+                                  "type": "string"
+                                },
+                                {
+                                  "default": "",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "contentText": {
+                              "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                              "default": "",
+                              "type": "string"
+                            },
+                            "fontStyle": {
+                              "default": "",
+                              "enum": [
+                                "normal",
+                                "italic",
+                                "oblique",
+                                ""
+                              ],
+                              "type": "string"
+                            },
+                            "fontWeight": {
+                              "enum": [
+                                "100",
+                                "200",
+                                "300",
+                                "400",
+                                "500",
+                                "600",
+                                "700",
+                                "800",
+                                "900",
+                                "bold",
+                                "medium"
+                              ],
+                              "type": "string",
+                              "default": "500"
+                            },
+                            "height": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "margin": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "textDecoration": {
+                              "default": "",
+                              "type": "string",
+                              "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                            },
+                            "width": {
+                              "default": "",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "backgroundColor": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "before": {
+                          "type": "object",
+                          "default": {},
+                          "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                          "properties": {
+                            "backgroundColor": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "border": {
+                              "default": "",
+                              "type": "string"
+                            },
+                            "borderColor": {
+                              "default": "#FFFFFF22",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "color": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "contentIconPath": {
+                              "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                              "oneOf": [
+                                {
+                                  "default": "",
+                                  "format": "uri",
+                                  "type": "string"
+                                },
+                                {
+                                  "default": "",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "contentText": {
+                              "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                              "default": "",
+                              "type": "string"
+                            },
+                            "fontStyle": {
+                              "default": "",
+                              "enum": [
+                                "normal",
+                                "italic",
+                                "oblique",
+                                ""
+                              ],
+                              "type": "string"
+                            },
+                            "fontWeight": {
+                              "enum": [
+                                "100",
+                                "200",
+                                "300",
+                                "400",
+                                "500",
+                                "600",
+                                "700",
+                                "800",
+                                "900",
+                                "bold",
+                                "medium"
+                              ],
+                              "type": "string",
+                              "default": "500"
+                            },
+                            "height": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "margin": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "textDecoration": {
+                              "default": "",
+                              "type": "string",
+                              "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                            },
+                            "width": {
+                              "default": "",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "border": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "borderColor": {
+                          "default": "#FFFFFF22",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "borderRadius": {
+                          "default": "4px",
+                          "examples": [
+                            "2px",
+                            "0.25em",
+                            "2px 0px",
+                            "0px 0px 0px 4px",
+                            "10px 40px / 20px 60px"
+                          ],
+                          "type": "string"
+                        },
+                        "borderSpacing": {
+                          "default": "2px",
+                          "type": "string"
+                        },
+                        "borderStyle": {
+                          "enum": [
+                            "solid",
+                            "dotted",
+                            "dashed"
+                          ],
+                          "type": "string",
+                          "default": ""
+                        },
+                        "borderWidth": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "color": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "cursor": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "fontStyle": {
+                          "default": "",
+                          "enum": [
+                            "normal",
+                            "italic",
+                            "oblique",
+                            ""
+                          ],
+                          "type": "string"
+                        },
+                        "fontWeight": {
+                          "enum": [
+                            "100",
+                            "200",
+                            "300",
+                            "400",
+                            "500",
+                            "600",
+                            "700",
+                            "800",
+                            "900",
+                            "bold",
+                            "medium"
+                          ],
+                          "type": "string",
+                          "default": "500"
+                        },
+                        "gutterIconPath": {
+                          "type": "string",
+                          "default": "",
+                          "format": "uri",
+                          "description": "An absolute path or an URI to an image to be rendered in the gutter."
+                        },
+                        "gutterIconSize": {
+                          "type": "string",
+                          "default": "",
+                          "description": "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+                          "oneOf": [
+                            {
+                              "pattern": "\\d+(\\.\\d+)%"
+                            },
+                            {
+                              "enum": [
+                                "auto",
+                                "contain",
+                                "cover"
+                              ]
+                            }
+                          ]
+                        },
+                        "letterSpacing": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "opacity": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "outline": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "outlineColor": {
+                          "type": "string",
+                          "default": "",
+                          "format": "color",
+                          "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                        },
+                        "outlineStyle": {
+                          "type": "string",
+                          "default": "",
+                          "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                        },
+                        "outlineWidth": {
+                          "type": "string",
+                          "default": "",
+                          "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                        },
+                        "overviewRulerColor": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string",
+                          "description": "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
+                        },
+                        "textDecoration": {
+                          "default": "",
+                          "type": "string",
+                          "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                        }
+                      }
+                    },
+                    "fontStyle": {
+                      "default": "",
+                      "enum": [
+                        "normal",
+                        "italic",
+                        "oblique",
+                        ""
+                      ],
+                      "type": "string"
+                    },
+                    "fontWeight": {
+                      "enum": [
+                        "100",
+                        "200",
+                        "300",
+                        "400",
+                        "500",
+                        "600",
+                        "700",
+                        "800",
+                        "900",
+                        "bold",
+                        "medium"
+                      ],
+                      "type": "string",
+                      "default": "500"
+                    },
+                    "gutterIconPath": {
+                      "type": "string",
+                      "default": "",
+                      "format": "uri",
+                      "description": "An absolute path or an URI to an image to be rendered in the gutter."
+                    },
+                    "gutterIconSize": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+                      "oneOf": [
+                        {
+                          "pattern": "\\d+(\\.\\d+)%"
+                        },
+                        {
+                          "enum": [
+                            "auto",
+                            "contain",
+                            "cover"
+                          ]
+                        }
+                      ]
+                    },
+                    "isWholeLine": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Should the decoration be rendered also on the whitespace after the line text."
+                    },
+                    "letterSpacing": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "light": {
+                      "type": "object",
+                      "description": "Overwrite options for light themes.",
+                      "default": {},
+                      "properties": {
+                        "after": {
+                          "type": "object",
+                          "default": {},
+                          "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                          "properties": {
+                            "backgroundColor": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "border": {
+                              "default": "",
+                              "type": "string"
+                            },
+                            "borderColor": {
+                              "default": "#FFFFFF22",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "color": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "contentIconPath": {
+                              "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                              "oneOf": [
+                                {
+                                  "default": "",
+                                  "format": "uri",
+                                  "type": "string"
+                                },
+                                {
+                                  "default": "",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "contentText": {
+                              "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                              "default": "",
+                              "type": "string"
+                            },
+                            "fontStyle": {
+                              "default": "",
+                              "enum": [
+                                "normal",
+                                "italic",
+                                "oblique",
+                                ""
+                              ],
+                              "type": "string"
+                            },
+                            "fontWeight": {
+                              "enum": [
+                                "100",
+                                "200",
+                                "300",
+                                "400",
+                                "500",
+                                "600",
+                                "700",
+                                "800",
+                                "900",
+                                "bold",
+                                "medium"
+                              ],
+                              "type": "string",
+                              "default": "500"
+                            },
+                            "height": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "margin": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "textDecoration": {
+                              "default": "",
+                              "type": "string",
+                              "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                            },
+                            "width": {
+                              "default": "",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "backgroundColor": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "before": {
+                          "type": "object",
+                          "default": {},
+                          "description": "Defines the rendering options of the attachment that is inserted before the decorated text.",
+                          "properties": {
+                            "backgroundColor": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "border": {
+                              "default": "",
+                              "type": "string"
+                            },
+                            "borderColor": {
+                              "default": "#FFFFFF22",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "color": {
+                              "default": "",
+                              "format": "color",
+                              "type": "string"
+                            },
+                            "contentIconPath": {
+                              "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+                              "oneOf": [
+                                {
+                                  "default": "",
+                                  "format": "uri",
+                                  "type": "string"
+                                },
+                                {
+                                  "default": "",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "contentText": {
+                              "description": "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+                              "default": "",
+                              "type": "string"
+                            },
+                            "fontStyle": {
+                              "default": "",
+                              "enum": [
+                                "normal",
+                                "italic",
+                                "oblique",
+                                ""
+                              ],
+                              "type": "string"
+                            },
+                            "fontWeight": {
+                              "enum": [
+                                "100",
+                                "200",
+                                "300",
+                                "400",
+                                "500",
+                                "600",
+                                "700",
+                                "800",
+                                "900",
+                                "bold",
+                                "medium"
+                              ],
+                              "type": "string",
+                              "default": "500"
+                            },
+                            "height": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "margin": {
+                              "type": "string",
+                              "default": ""
+                            },
+                            "textDecoration": {
+                              "default": "",
+                              "type": "string",
+                              "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                            },
+                            "width": {
+                              "default": "",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "border": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "borderColor": {
+                          "default": "#FFFFFF22",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "borderRadius": {
+                          "default": "4px",
+                          "examples": [
+                            "2px",
+                            "0.25em",
+                            "2px 0px",
+                            "0px 0px 0px 4px",
+                            "10px 40px / 20px 60px"
+                          ],
+                          "type": "string"
+                        },
+                        "borderSpacing": {
+                          "default": "2px",
+                          "type": "string"
+                        },
+                        "borderStyle": {
+                          "enum": [
+                            "solid",
+                            "dotted",
+                            "dashed"
+                          ],
+                          "type": "string",
+                          "default": ""
+                        },
+                        "borderWidth": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "color": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string"
+                        },
+                        "cursor": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "fontStyle": {
+                          "default": "",
+                          "enum": [
+                            "normal",
+                            "italic",
+                            "oblique",
+                            ""
+                          ],
+                          "type": "string"
+                        },
+                        "fontWeight": {
+                          "enum": [
+                            "100",
+                            "200",
+                            "300",
+                            "400",
+                            "500",
+                            "600",
+                            "700",
+                            "800",
+                            "900",
+                            "bold",
+                            "medium"
+                          ],
+                          "type": "string",
+                          "default": "500"
+                        },
+                        "gutterIconPath": {
+                          "type": "string",
+                          "default": "",
+                          "format": "uri",
+                          "description": "An absolute path or an URI to an image to be rendered in the gutter."
+                        },
+                        "gutterIconSize": {
+                          "type": "string",
+                          "default": "",
+                          "description": "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+                          "oneOf": [
+                            {
+                              "pattern": "\\d+(\\.\\d+)%"
+                            },
+                            {
+                              "enum": [
+                                "auto",
+                                "contain",
+                                "cover"
+                              ]
+                            }
+                          ]
+                        },
+                        "letterSpacing": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "opacity": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "outline": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "outlineColor": {
+                          "type": "string",
+                          "default": "",
+                          "format": "color",
+                          "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                        },
+                        "outlineStyle": {
+                          "type": "string",
+                          "default": "",
+                          "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                        },
+                        "outlineWidth": {
+                          "type": "string",
+                          "default": "",
+                          "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                        },
+                        "overviewRulerColor": {
+                          "default": "",
+                          "format": "color",
+                          "type": "string",
+                          "description": "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
+                        },
+                        "textDecoration": {
+                          "default": "",
+                          "type": "string",
+                          "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                        }
+                      }
+                    },
+                    "opacity": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "outline": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "outlineColor": {
+                      "type": "string",
+                      "default": "",
+                      "format": "color",
+                      "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                    },
+                    "outlineStyle": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                    },
+                    "outlineWidth": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+                    },
+                    "overviewRulerColor": {
+                      "default": "",
+                      "format": "color",
+                      "type": "string",
+                      "description": "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
+                    },
+                    "overviewRulerLane": {
+                      "description": "The position in the overview ruler where the decoration should be rendered.",
+                      "enum": [
+                        "center",
+                        "full",
+                        "left",
+                        "right"
+                      ],
+                      "type": "string",
+                      "default": "center"
+                    },
+                    "rangeBehavior": {
+                      "enum": [
+                        1,
+                        2,
+                        3,
+                        4
+                      ],
+                      "type": "number",
+                      "default": 3,
+                      "description": "Customize the growing behavior of the decoration when edits occur at the edges of the decoration's range."
+                    },
+                    "textDecoration": {
+                      "default": "",
+                      "type": "string",
+                      "description": "CSS styling property that will be applied to text enclosed by a decoration."
+                    }
+                  },
+                  "default": {}
+                }
+              }
+            }
+          }
         },
         "highlight.regexFlags": {
           "type": "string",
           "description": "Flags used when building the regexes",
+          "pattern": "^((?:([gmi])(?!.*\\2))*)$",
           "default": "gi"
         },
         "highlight.maxMatches": {

--- a/package.json
+++ b/package.json
@@ -67,11 +67,10 @@
                 },
                 "fontStyle": {
                   "default": "",
-                  "enum": [
+                  "examples": [
                     "normal",
                     "italic",
-                    "oblique",
-                    ""
+                    "oblique"
                   ],
                   "type": "string"
                 },
@@ -161,11 +160,10 @@
                 },
                 "fontStyle": {
                   "default": "",
-                  "enum": [
+                  "examples": [
                     "normal",
                     "italic",
-                    "oblique",
-                    ""
+                    "oblique"
                   ],
                   "type": "string"
                 },
@@ -230,7 +228,7 @@
               "type": "string"
             },
             "borderStyle": {
-              "enum": [
+              "examples": [
                 "solid",
                 "dotted",
                 "dashed"
@@ -320,11 +318,10 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "enum": [
+                      "examples": [
                         "normal",
                         "italic",
-                        "oblique",
-                        ""
+                        "oblique"
                       ],
                       "type": "string"
                     },
@@ -414,11 +411,10 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "enum": [
+                      "examples": [
                         "normal",
                         "italic",
-                        "oblique",
-                        ""
+                        "oblique"
                       ],
                       "type": "string"
                     },
@@ -483,7 +479,7 @@
                   "type": "string"
                 },
                 "borderStyle": {
-                  "enum": [
+                  "examples": [
                     "solid",
                     "dotted",
                     "dashed"
@@ -506,11 +502,10 @@
                 },
                 "fontStyle": {
                   "default": "",
-                  "enum": [
+                  "examples": [
                     "normal",
                     "italic",
-                    "oblique",
-                    ""
+                    "oblique"
                   ],
                   "type": "string"
                 },
@@ -597,11 +592,10 @@
             },
             "fontStyle": {
               "default": "",
-              "enum": [
+              "examples": [
                 "normal",
                 "italic",
-                "oblique",
-                ""
+                "oblique"
               ],
               "type": "string"
             },
@@ -704,11 +698,10 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "enum": [
+                      "examples": [
                         "normal",
                         "italic",
-                        "oblique",
-                        ""
+                        "oblique"
                       ],
                       "type": "string"
                     },
@@ -798,11 +791,10 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "enum": [
+                      "examples": [
                         "normal",
                         "italic",
-                        "oblique",
-                        ""
+                        "oblique"
                       ],
                       "type": "string"
                     },
@@ -867,7 +859,7 @@
                   "type": "string"
                 },
                 "borderStyle": {
-                  "enum": [
+                  "examples": [
                     "solid",
                     "dotted",
                     "dashed"
@@ -890,11 +882,10 @@
                 },
                 "fontStyle": {
                   "default": "",
-                  "enum": [
+                  "examples": [
                     "normal",
                     "italic",
-                    "oblique",
-                    ""
+                    "oblique"
                   ],
                   "type": "string"
                 },
@@ -1106,11 +1097,10 @@
                         },
                         "fontStyle": {
                           "default": "",
-                          "enum": [
+                          "examples": [
                             "normal",
                             "italic",
-                            "oblique",
-                            ""
+                            "oblique"
                           ],
                           "type": "string"
                         },
@@ -1200,11 +1190,10 @@
                         },
                         "fontStyle": {
                           "default": "",
-                          "enum": [
+                          "examples": [
                             "normal",
                             "italic",
-                            "oblique",
-                            ""
+                            "oblique"
                           ],
                           "type": "string"
                         },
@@ -1269,7 +1258,7 @@
                       "type": "string"
                     },
                     "borderStyle": {
-                      "enum": [
+                      "examples": [
                         "solid",
                         "dotted",
                         "dashed"
@@ -1359,11 +1348,10 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "enum": [
+                              "examples": [
                                 "normal",
                                 "italic",
-                                "oblique",
-                                ""
+                                "oblique"
                               ],
                               "type": "string"
                             },
@@ -1453,11 +1441,10 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "enum": [
+                              "examples": [
                                 "normal",
                                 "italic",
-                                "oblique",
-                                ""
+                                "oblique"
                               ],
                               "type": "string"
                             },
@@ -1522,7 +1509,7 @@
                           "type": "string"
                         },
                         "borderStyle": {
-                          "enum": [
+                          "examples": [
                             "solid",
                             "dotted",
                             "dashed"
@@ -1545,11 +1532,10 @@
                         },
                         "fontStyle": {
                           "default": "",
-                          "enum": [
+                          "examples": [
                             "normal",
                             "italic",
-                            "oblique",
-                            ""
+                            "oblique"
                           ],
                           "type": "string"
                         },
@@ -1636,11 +1622,10 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "enum": [
+                      "examples": [
                         "normal",
                         "italic",
-                        "oblique",
-                        ""
+                        "oblique"
                       ],
                       "type": "string"
                     },
@@ -1743,11 +1728,10 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "enum": [
+                              "examples": [
                                 "normal",
                                 "italic",
-                                "oblique",
-                                ""
+                                "oblique"
                               ],
                               "type": "string"
                             },
@@ -1837,11 +1821,10 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "enum": [
+                              "examples": [
                                 "normal",
                                 "italic",
-                                "oblique",
-                                ""
+                                "oblique"
                               ],
                               "type": "string"
                             },
@@ -1906,7 +1889,7 @@
                           "type": "string"
                         },
                         "borderStyle": {
-                          "enum": [
+                          "examples": [
                             "solid",
                             "dotted",
                             "dashed"
@@ -1929,11 +1912,10 @@
                         },
                         "fontStyle": {
                           "default": "",
-                          "enum": [
+                          "examples": [
                             "normal",
                             "italic",
-                            "oblique",
-                            ""
+                            "oblique"
                           ],
                           "type": "string"
                         },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
                 },
                 "contentIconPath": {
                   "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "default": "",
                       "format": "uri",
@@ -67,10 +67,12 @@
                 },
                 "fontStyle": {
                   "default": "",
-                  "examples": [
+                  "enum": [
                     "normal",
                     "italic",
-                    "oblique"
+                    "oblique",
+                    "unset",
+                    ""
                   ],
                   "type": "string"
                 },
@@ -141,7 +143,7 @@
                 },
                 "contentIconPath": {
                   "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "default": "",
                       "format": "uri",
@@ -160,10 +162,12 @@
                 },
                 "fontStyle": {
                   "default": "",
-                  "examples": [
+                  "enum": [
                     "normal",
                     "italic",
-                    "oblique"
+                    "oblique",
+                    "unset",
+                    ""
                   ],
                   "type": "string"
                 },
@@ -231,7 +235,9 @@
               "examples": [
                 "solid",
                 "dotted",
-                "dashed"
+                "dashed",
+                "solid none",
+                "none none solid none"
               ],
               "type": "string",
               "default": ""
@@ -247,7 +253,7 @@
             },
             "contentIconPath": {
               "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-              "oneOf": [
+              "anyOf": [
                 {
                   "default": "",
                   "format": "uri",
@@ -265,7 +271,55 @@
               "type": "string"
             },
             "cursor": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "alias",
+                    "all-scroll",
+                    "auto",
+                    "cell",
+                    "context-menu",
+                    "col-resize",
+                    "copy",
+                    "crosshair",
+                    "default",
+                    "e-resize",
+                    "ew-resize",
+                    "grab",
+                    "grabbing",
+                    "help",
+                    "move",
+                    "n-resize",
+                    "ne-resize",
+                    "nesw-resize",
+                    "ns-resize",
+                    "nw-resize",
+                    "nwse-resize",
+                    "no-drop",
+                    "none",
+                    "not-allowed",
+                    "pointer",
+                    "progress",
+                    "row-resize",
+                    "s-resize",
+                    "se-resize",
+                    "sw-resize",
+                    "text",
+                    "vertical-text",
+                    "w-resize",
+                    "wait",
+                    "zoom-in",
+                    "zoom-out",
+                    "initial",
+                    "inherit"
+                  ]
+                },
+                {
+                  "format": "uri"
+                }
+              ],
               "default": "",
+              "description": "Specifies the mouse cursor to be displayed when pointing over a decoration.",
               "type": "string"
             },
             "dark": {
@@ -299,7 +353,7 @@
                     },
                     "contentIconPath": {
                       "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "default": "",
                           "format": "uri",
@@ -318,10 +372,12 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "examples": [
+                      "enum": [
                         "normal",
                         "italic",
-                        "oblique"
+                        "oblique",
+                        "unset",
+                        ""
                       ],
                       "type": "string"
                     },
@@ -392,7 +448,7 @@
                     },
                     "contentIconPath": {
                       "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "default": "",
                           "format": "uri",
@@ -411,10 +467,12 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "examples": [
+                      "enum": [
                         "normal",
                         "italic",
-                        "oblique"
+                        "oblique",
+                        "unset",
+                        ""
                       ],
                       "type": "string"
                     },
@@ -482,7 +540,9 @@
                   "examples": [
                     "solid",
                     "dotted",
-                    "dashed"
+                    "dashed",
+                    "solid none",
+                    "none none solid none"
                   ],
                   "type": "string",
                   "default": ""
@@ -497,15 +557,65 @@
                   "type": "string"
                 },
                 "cursor": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "alias",
+                        "all-scroll",
+                        "auto",
+                        "cell",
+                        "context-menu",
+                        "col-resize",
+                        "copy",
+                        "crosshair",
+                        "default",
+                        "e-resize",
+                        "ew-resize",
+                        "grab",
+                        "grabbing",
+                        "help",
+                        "move",
+                        "n-resize",
+                        "ne-resize",
+                        "nesw-resize",
+                        "ns-resize",
+                        "nw-resize",
+                        "nwse-resize",
+                        "no-drop",
+                        "none",
+                        "not-allowed",
+                        "pointer",
+                        "progress",
+                        "row-resize",
+                        "s-resize",
+                        "se-resize",
+                        "sw-resize",
+                        "text",
+                        "vertical-text",
+                        "w-resize",
+                        "wait",
+                        "zoom-in",
+                        "zoom-out",
+                        "initial",
+                        "inherit"
+                      ]
+                    },
+                    {
+                      "format": "uri"
+                    }
+                  ],
                   "default": "",
+                  "description": "Specifies the mouse cursor to be displayed when pointing over a decoration.",
                   "type": "string"
                 },
                 "fontStyle": {
                   "default": "",
-                  "examples": [
+                  "enum": [
                     "normal",
                     "italic",
-                    "oblique"
+                    "oblique",
+                    "unset",
+                    ""
                   ],
                   "type": "string"
                 },
@@ -554,8 +664,10 @@
                   "default": ""
                 },
                 "opacity": {
-                  "type": "string",
-                  "default": ""
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "default": 1
                 },
                 "outline": {
                   "type": "string",
@@ -592,10 +704,12 @@
             },
             "fontStyle": {
               "default": "",
-              "examples": [
+              "enum": [
                 "normal",
                 "italic",
-                "oblique"
+                "oblique",
+                "unset",
+                ""
               ],
               "type": "string"
             },
@@ -679,7 +793,7 @@
                     },
                     "contentIconPath": {
                       "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "default": "",
                           "format": "uri",
@@ -698,10 +812,12 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "examples": [
+                      "enum": [
                         "normal",
                         "italic",
-                        "oblique"
+                        "oblique",
+                        "unset",
+                        ""
                       ],
                       "type": "string"
                     },
@@ -772,7 +888,7 @@
                     },
                     "contentIconPath": {
                       "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "default": "",
                           "format": "uri",
@@ -791,10 +907,12 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "examples": [
+                      "enum": [
                         "normal",
                         "italic",
-                        "oblique"
+                        "oblique",
+                        "unset",
+                        ""
                       ],
                       "type": "string"
                     },
@@ -862,7 +980,9 @@
                   "examples": [
                     "solid",
                     "dotted",
-                    "dashed"
+                    "dashed",
+                    "solid none",
+                    "none none solid none"
                   ],
                   "type": "string",
                   "default": ""
@@ -877,15 +997,65 @@
                   "type": "string"
                 },
                 "cursor": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "alias",
+                        "all-scroll",
+                        "auto",
+                        "cell",
+                        "context-menu",
+                        "col-resize",
+                        "copy",
+                        "crosshair",
+                        "default",
+                        "e-resize",
+                        "ew-resize",
+                        "grab",
+                        "grabbing",
+                        "help",
+                        "move",
+                        "n-resize",
+                        "ne-resize",
+                        "nesw-resize",
+                        "ns-resize",
+                        "nw-resize",
+                        "nwse-resize",
+                        "no-drop",
+                        "none",
+                        "not-allowed",
+                        "pointer",
+                        "progress",
+                        "row-resize",
+                        "s-resize",
+                        "se-resize",
+                        "sw-resize",
+                        "text",
+                        "vertical-text",
+                        "w-resize",
+                        "wait",
+                        "zoom-in",
+                        "zoom-out",
+                        "initial",
+                        "inherit"
+                      ]
+                    },
+                    {
+                      "format": "uri"
+                    }
+                  ],
                   "default": "",
+                  "description": "Specifies the mouse cursor to be displayed when pointing over a decoration.",
                   "type": "string"
                 },
                 "fontStyle": {
                   "default": "",
-                  "examples": [
+                  "enum": [
                     "normal",
                     "italic",
-                    "oblique"
+                    "oblique",
+                    "unset",
+                    ""
                   ],
                   "type": "string"
                 },
@@ -934,8 +1104,10 @@
                   "default": ""
                 },
                 "opacity": {
-                  "type": "string",
-                  "default": ""
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "default": 1
                 },
                 "outline": {
                   "type": "string",
@@ -971,8 +1143,10 @@
               }
             },
             "opacity": {
-              "type": "string",
-              "default": ""
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "default": 1
             },
             "outline": {
               "type": "string",
@@ -1078,7 +1252,7 @@
                         },
                         "contentIconPath": {
                           "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "default": "",
                               "format": "uri",
@@ -1097,10 +1271,12 @@
                         },
                         "fontStyle": {
                           "default": "",
-                          "examples": [
+                          "enum": [
                             "normal",
                             "italic",
-                            "oblique"
+                            "oblique",
+                            "unset",
+                            ""
                           ],
                           "type": "string"
                         },
@@ -1171,7 +1347,7 @@
                         },
                         "contentIconPath": {
                           "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "default": "",
                               "format": "uri",
@@ -1190,10 +1366,12 @@
                         },
                         "fontStyle": {
                           "default": "",
-                          "examples": [
+                          "enum": [
                             "normal",
                             "italic",
-                            "oblique"
+                            "oblique",
+                            "unset",
+                            ""
                           ],
                           "type": "string"
                         },
@@ -1261,7 +1439,9 @@
                       "examples": [
                         "solid",
                         "dotted",
-                        "dashed"
+                        "dashed",
+                        "solid none",
+                        "none none solid none"
                       ],
                       "type": "string",
                       "default": ""
@@ -1277,7 +1457,7 @@
                     },
                     "contentIconPath": {
                       "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "default": "",
                           "format": "uri",
@@ -1295,7 +1475,55 @@
                       "type": "string"
                     },
                     "cursor": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "alias",
+                            "all-scroll",
+                            "auto",
+                            "cell",
+                            "context-menu",
+                            "col-resize",
+                            "copy",
+                            "crosshair",
+                            "default",
+                            "e-resize",
+                            "ew-resize",
+                            "grab",
+                            "grabbing",
+                            "help",
+                            "move",
+                            "n-resize",
+                            "ne-resize",
+                            "nesw-resize",
+                            "ns-resize",
+                            "nw-resize",
+                            "nwse-resize",
+                            "no-drop",
+                            "none",
+                            "not-allowed",
+                            "pointer",
+                            "progress",
+                            "row-resize",
+                            "s-resize",
+                            "se-resize",
+                            "sw-resize",
+                            "text",
+                            "vertical-text",
+                            "w-resize",
+                            "wait",
+                            "zoom-in",
+                            "zoom-out",
+                            "initial",
+                            "inherit"
+                          ]
+                        },
+                        {
+                          "format": "uri"
+                        }
+                      ],
                       "default": "",
+                      "description": "Specifies the mouse cursor to be displayed when pointing over a decoration.",
                       "type": "string"
                     },
                     "dark": {
@@ -1329,7 +1557,7 @@
                             },
                             "contentIconPath": {
                               "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                              "oneOf": [
+                              "anyOf": [
                                 {
                                   "default": "",
                                   "format": "uri",
@@ -1348,10 +1576,12 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "examples": [
+                              "enum": [
                                 "normal",
                                 "italic",
-                                "oblique"
+                                "oblique",
+                                "unset",
+                                ""
                               ],
                               "type": "string"
                             },
@@ -1422,7 +1652,7 @@
                             },
                             "contentIconPath": {
                               "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                              "oneOf": [
+                              "anyOf": [
                                 {
                                   "default": "",
                                   "format": "uri",
@@ -1441,10 +1671,12 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "examples": [
+                              "enum": [
                                 "normal",
                                 "italic",
-                                "oblique"
+                                "oblique",
+                                "unset",
+                                ""
                               ],
                               "type": "string"
                             },
@@ -1512,7 +1744,9 @@
                           "examples": [
                             "solid",
                             "dotted",
-                            "dashed"
+                            "dashed",
+                            "solid none",
+                            "none none solid none"
                           ],
                           "type": "string",
                           "default": ""
@@ -1527,15 +1761,65 @@
                           "type": "string"
                         },
                         "cursor": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "alias",
+                                "all-scroll",
+                                "auto",
+                                "cell",
+                                "context-menu",
+                                "col-resize",
+                                "copy",
+                                "crosshair",
+                                "default",
+                                "e-resize",
+                                "ew-resize",
+                                "grab",
+                                "grabbing",
+                                "help",
+                                "move",
+                                "n-resize",
+                                "ne-resize",
+                                "nesw-resize",
+                                "ns-resize",
+                                "nw-resize",
+                                "nwse-resize",
+                                "no-drop",
+                                "none",
+                                "not-allowed",
+                                "pointer",
+                                "progress",
+                                "row-resize",
+                                "s-resize",
+                                "se-resize",
+                                "sw-resize",
+                                "text",
+                                "vertical-text",
+                                "w-resize",
+                                "wait",
+                                "zoom-in",
+                                "zoom-out",
+                                "initial",
+                                "inherit"
+                              ]
+                            },
+                            {
+                              "format": "uri"
+                            }
+                          ],
                           "default": "",
+                          "description": "Specifies the mouse cursor to be displayed when pointing over a decoration.",
                           "type": "string"
                         },
                         "fontStyle": {
                           "default": "",
-                          "examples": [
+                          "enum": [
                             "normal",
                             "italic",
-                            "oblique"
+                            "oblique",
+                            "unset",
+                            ""
                           ],
                           "type": "string"
                         },
@@ -1584,8 +1868,10 @@
                           "default": ""
                         },
                         "opacity": {
-                          "type": "string",
-                          "default": ""
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "default": 1
                         },
                         "outline": {
                           "type": "string",
@@ -1622,10 +1908,12 @@
                     },
                     "fontStyle": {
                       "default": "",
-                      "examples": [
+                      "enum": [
                         "normal",
                         "italic",
-                        "oblique"
+                        "oblique",
+                        "unset",
+                        ""
                       ],
                       "type": "string"
                     },
@@ -1709,7 +1997,7 @@
                             },
                             "contentIconPath": {
                               "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                              "oneOf": [
+                              "anyOf": [
                                 {
                                   "default": "",
                                   "format": "uri",
@@ -1728,10 +2016,12 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "examples": [
+                              "enum": [
                                 "normal",
                                 "italic",
-                                "oblique"
+                                "oblique",
+                                "unset",
+                                ""
                               ],
                               "type": "string"
                             },
@@ -1802,7 +2092,7 @@
                             },
                             "contentIconPath": {
                               "description": "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-                              "oneOf": [
+                              "anyOf": [
                                 {
                                   "default": "",
                                   "format": "uri",
@@ -1821,10 +2111,12 @@
                             },
                             "fontStyle": {
                               "default": "",
-                              "examples": [
+                              "enum": [
                                 "normal",
                                 "italic",
-                                "oblique"
+                                "oblique",
+                                "unset",
+                                ""
                               ],
                               "type": "string"
                             },
@@ -1892,7 +2184,9 @@
                           "examples": [
                             "solid",
                             "dotted",
-                            "dashed"
+                            "dashed",
+                            "solid none",
+                            "none none solid none"
                           ],
                           "type": "string",
                           "default": ""
@@ -1907,15 +2201,65 @@
                           "type": "string"
                         },
                         "cursor": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "alias",
+                                "all-scroll",
+                                "auto",
+                                "cell",
+                                "context-menu",
+                                "col-resize",
+                                "copy",
+                                "crosshair",
+                                "default",
+                                "e-resize",
+                                "ew-resize",
+                                "grab",
+                                "grabbing",
+                                "help",
+                                "move",
+                                "n-resize",
+                                "ne-resize",
+                                "nesw-resize",
+                                "ns-resize",
+                                "nw-resize",
+                                "nwse-resize",
+                                "no-drop",
+                                "none",
+                                "not-allowed",
+                                "pointer",
+                                "progress",
+                                "row-resize",
+                                "s-resize",
+                                "se-resize",
+                                "sw-resize",
+                                "text",
+                                "vertical-text",
+                                "w-resize",
+                                "wait",
+                                "zoom-in",
+                                "zoom-out",
+                                "initial",
+                                "inherit"
+                              ]
+                            },
+                            {
+                              "format": "uri"
+                            }
+                          ],
                           "default": "",
+                          "description": "Specifies the mouse cursor to be displayed when pointing over a decoration.",
                           "type": "string"
                         },
                         "fontStyle": {
                           "default": "",
-                          "examples": [
+                          "enum": [
                             "normal",
                             "italic",
-                            "oblique"
+                            "oblique",
+                            "unset",
+                            ""
                           ],
                           "type": "string"
                         },
@@ -1964,8 +2308,10 @@
                           "default": ""
                         },
                         "opacity": {
-                          "type": "string",
-                          "default": ""
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "default": 1
                         },
                         "outline": {
                           "type": "string",
@@ -2001,8 +2347,10 @@
                       }
                     },
                     "opacity": {
-                      "type": "string",
-                      "default": ""
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1,
+                      "default": 1
                     },
                     "outline": {
                       "type": "string",
@@ -2119,6 +2467,7 @@
     "string-matches": "^1.1.0"
   },
   "devDependencies": {
+    "@types/json-schema": "^7.0.5",
     "ts-loader": "^5.2.1",
     "typescript": "~2.4.1",
     "vscode": "^1.1.4",

--- a/schemas/configuration.js
+++ b/schemas/configuration.js
@@ -35,7 +35,7 @@ const prop = {
         type: "string",
     },
     borderStyle: {
-        enum: ["solid", "dotted", "dashed"],
+        examples: ["solid", "dotted", "dashed"],
         type: "string",
         default: "",
     },
@@ -79,8 +79,10 @@ const prop = {
     },
     fontStyle: {
         default: "",
-        enum: ["normal", "italic", "oblique", ""],
-        type: "string",
+        examples: [
+          "normal", "italic", "oblique"
+        ],
+        type: "string"
     },
     fontWeight: {
         enum: [

--- a/schemas/configuration.js
+++ b/schemas/configuration.js
@@ -1,0 +1,383 @@
+"use strict";
+/**
+ * Creation/composition of extension configuration related JSON objects, due to
+ * JSON schema support being "odd" in regards to VSCode settings contributions
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+const prop = {
+    backgroundColor: {
+        default: "",
+        format: "color",
+        type: "string"
+    },
+    border: {
+        default: "",
+        type: "string",
+    },
+    borderColor: {
+        default: "#FFFFFF22",
+        format: "color",
+        type: "string",
+    },
+    borderRadius: {
+        default: "4px",
+        examples: [
+            "2px",
+            "0.25em",
+            "2px 0px",
+            "0px 0px 0px 4px",
+            "10px 40px / 20px 60px",
+        ],
+        type: "string",
+    },
+    borderSpacing: {
+        default: "2px",
+        type: "string",
+    },
+    borderStyle: {
+        enum: ["solid", "dotted", "dashed"],
+        type: "string",
+        default: "",
+    },
+    borderWidth: {
+        type: "string",
+        default: "",
+    },
+    color: {
+        default: "",
+        format: "color",
+        type: "string",
+    },
+    contentIconPath: {
+        description: "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+        oneOf: [
+            {
+                default: "",
+                format: "uri",
+                type: "string",
+            },
+            {
+                default: "",
+                type: "string",
+            },
+        ],
+    },
+    contentText: {
+        description: "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+        default: "",
+        type: "string",
+    },
+    cursor: {
+        default: "",
+        type: "string",
+    },
+    filterFileRegex: {
+        type: "string",
+    },
+    filterLanguageRegex: {
+        type: "string",
+    },
+    fontStyle: {
+        default: "",
+        enum: ["normal", "italic", "oblique", ""],
+        type: "string",
+    },
+    fontWeight: {
+        enum: [
+            "100",
+            "200",
+            "300",
+            "400",
+            "500",
+            "600",
+            "700",
+            "800",
+            "900",
+            "bold",
+            "medium",
+        ],
+        type: "string",
+        default: "500",
+    },
+    gutterIconPath: {
+        type: "string",
+        default: "",
+        format: "uri",
+        description: "An absolute path or an URI to an image to be rendered in the gutter.",
+    },
+    gutterIconSize: {
+        type: "string",
+        default: "",
+        description: "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+        oneOf: [
+            { pattern: "\\d+(\\.\\d+)%" },
+            {
+                enum: [
+                    'auto',
+                    'contain',
+                    'cover'
+                ]
+            }
+        ]
+    },
+    height: {
+        type: "string",
+        default: "",
+    },
+    isWholeLine: {
+        type: "boolean",
+        default: false,
+        description: "Should the decoration be rendered also on the whitespace after the line text."
+    },
+    letterSpacing: {
+        type: "string",
+        default: "",
+    },
+    margin: {
+        type: "string",
+        default: "",
+    },
+    opacity: {
+        type: "string",
+        default: "",
+    },
+    outline: {
+        type: "string",
+        default: "",
+    },
+    outlineColor: {
+        type: "string",
+        default: "",
+        format: "color",
+        description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+    },
+    outlineStyle: {
+        type: "string",
+        default: "",
+        description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+    },
+    outlineWidth: {
+        type: "string",
+        default: "",
+        description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+    },
+    overviewRulerColor: {
+        default: "",
+        format: "color",
+        type: "string",
+        description: "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations.",
+    },
+    overviewRulerLane: {
+        description: "The position in the overview ruler where the decoration should be rendered.",
+        enum: ["center", "full", "left", "right"],
+        type: "string",
+        default: "center",
+    },
+    rangeBehavior: {
+        enum: [1, 2, 3, 4],
+        type: "number",
+        default: 3,
+        description: "Customize the growing behavior of the decoration when edits occur at the edges of the decoration's range."
+    },
+    textDecoration: {
+        default: "",
+        type: "string",
+        description: "CSS styling property that will be applied to text enclosed by a decoration."
+    },
+    width: {
+        default: "",
+        type: "string",
+    },
+};
+const propList = {
+    /**
+    * Decoration schema's properties list. Used for `highlight.regexes` and
+    * `highlight.decorations` properties
+    */
+    get decorationRenderOptions() {
+        return {
+            after: schemaObj.after,
+            backgroundColor: prop.backgroundColor,
+            before: schemaObj.before,
+            border: prop.border,
+            borderColor: prop.borderColor,
+            borderRadius: prop.borderRadius,
+            borderSpacing: prop.borderSpacing,
+            borderStyle: prop.borderStyle,
+            borderWidth: prop.borderWidth,
+            color: prop.color,
+            contentIconPath: prop.contentIconPath,
+            contentText: prop.contentText,
+            cursor: prop.cursor,
+            dark: schemaObj.dark,
+            fontStyle: prop.fontStyle,
+            fontWeight: prop.fontWeight,
+            gutterIconPath: prop.gutterIconPath,
+            gutterIconSize: prop.gutterIconSize,
+            isWholeLine: prop.isWholeLine,
+            letterSpacing: prop.letterSpacing,
+            light: schemaObj.light,
+            opacity: prop.opacity,
+            outline: prop.outline,
+            outlineColor: prop.outlineColor,
+            outlineStyle: prop.outlineStyle,
+            outlineWidth: prop.outlineWidth,
+            overviewRulerColor: prop.overviewRulerColor,
+            overviewRulerLane: prop.overviewRulerLane,
+            rangeBehavior: prop.rangeBehavior,
+            textDecoration: prop.textDecoration,
+        };
+    },
+    get themableDecorationRenderOptions() {
+        return {
+            after: schemaObj.after,
+            backgroundColor: prop.backgroundColor,
+            before: schemaObj.before,
+            border: prop.border,
+            borderColor: prop.borderColor,
+            borderRadius: prop.borderRadius,
+            borderSpacing: prop.borderSpacing,
+            borderStyle: prop.borderStyle,
+            borderWidth: prop.borderWidth,
+            color: prop.color,
+            cursor: prop.cursor,
+            fontStyle: prop.fontStyle,
+            fontWeight: prop.fontWeight,
+            gutterIconPath: prop.gutterIconPath,
+            gutterIconSize: prop.gutterIconSize,
+            letterSpacing: prop.letterSpacing,
+            opacity: prop.opacity,
+            outline: prop.outline,
+            outlineColor: prop.outlineColor,
+            outlineStyle: prop.outlineStyle,
+            outlineWidth: prop.outlineWidth,
+            overviewRulerColor: prop.overviewRulerColor,
+            textDecoration: prop.textDecoration,
+        };
+    },
+    get themableDecorationAttachmentRenderOptions() {
+        return {
+            backgroundColor: prop.backgroundColor,
+            border: prop.border,
+            borderColor: prop.borderColor,
+            color: prop.color,
+            contentIconPath: prop.contentIconPath,
+            contentText: prop.contentText,
+            fontStyle: prop.fontStyle,
+            fontWeight: prop.fontWeight,
+            height: prop.height,
+            margin: prop.margin,
+            textDecoration: prop.textDecoration,
+            width: prop.width,
+        };
+    },
+};
+const schemaObj = {
+    /**
+     * Decoration schema. Used for `highlight.regexes` and `highlight.decorations`
+     */
+    get decoration() {
+        return {
+            type: "object",
+            description: "Object mapping regexes to an array of decorations to apply to the capturing groups",
+            default: {},
+            properties: propList.decorationRenderOptions,
+        };
+    },
+    get regexFlags() {
+        return {
+            type: "string",
+            description: "Flags used when building the regexes",
+            pattern: "^((?:([gmi])(?!.*\\2))*)$",
+            default: "gi"
+        };
+    },
+    get after() {
+        return {
+            type: "object",
+            default: {},
+            description: "Defines the rendering options of the attachment that is inserted before the decorated text.",
+            properties: propList.themableDecorationAttachmentRenderOptions
+        };
+    },
+    get before() {
+        return {
+            type: "object",
+            default: {},
+            description: "Defines the rendering options of the attachment that is inserted before the decorated text.",
+            properties: propList.themableDecorationAttachmentRenderOptions
+        };
+    },
+    get dark() {
+        return {
+            type: "object",
+            description: "Overwrite options for dark themes.",
+            default: {},
+            properties: propList.themableDecorationRenderOptions
+        };
+    },
+    get light() {
+        return {
+            type: "object",
+            description: "Overwrite options for light themes.",
+            default: {},
+            properties: propList.themableDecorationRenderOptions
+        };
+    }
+};
+const configuration = {
+    type: "object",
+    title: "Highlight - Configuration",
+    properties: {
+        "highlight.decorations": {
+            type: "object",
+            description: "Default decorations from which all others inherit from",
+            default: { rangeBehavior: 3 },
+            properties: propList.decorationRenderOptions,
+        },
+        "highlight.regexes": {
+            type: "object",
+            description: "Object mapping regexes to an array of decorations to apply to the capturing groups",
+            default: {},
+            additionalProperties: {
+                properties: {
+                    filterFileRegex: prop.filterFileRegex,
+                    filterLanguageRegex: prop.filterFileRegex,
+                    regexFlags: schemaObj.regexFlags,
+                    decorations: {
+                        type: "array",
+                        items: {
+                            type: "object",
+                            properties: propList.decorationRenderOptions,
+                            default: {},
+                        },
+                    },
+                },
+            },
+        },
+        "highlight.regexFlags": schemaObj.regexFlags,
+        "highlight.maxMatches": {
+            type: "number",
+            description: "Maximum number of matches to decorate per regex, in order not to crash the app with accidental cathastropic regexes",
+            default: 250,
+        },
+    },
+};
+const indentLevel = 2;
+class ConfigurationGenerator {
+    constructor(configuration) {
+        this.indentLevel = indentLevel;
+        this.configuration = configuration;
+    }
+    toString() {
+        const output = JSON.stringify(configuration, null, this.indentLevel);
+        if (!output)
+            throw new Error('Generating schema failed.');
+        return output;
+    }
+    toJSON() {
+        // Not sure why I had to do this
+        return JSON.parse(JSON.stringify(this.configuration));
+    }
+}
+exports.default = new ConfigurationGenerator(configuration);

--- a/schemas/configuration.js
+++ b/schemas/configuration.js
@@ -12,12 +12,12 @@ const prop = {
     },
     border: {
         default: "",
-        type: "string",
+        type: "string"
     },
     borderColor: {
         default: "#FFFFFF22",
         format: "color",
-        type: "string",
+        type: "string"
     },
     borderRadius: {
         default: "4px",
@@ -28,60 +28,112 @@ const prop = {
             "0px 0px 0px 4px",
             "10px 40px / 20px 60px",
         ],
-        type: "string",
+        type: "string"
     },
     borderSpacing: {
         default: "2px",
-        type: "string",
+        type: "string"
     },
     borderStyle: {
-        examples: ["solid", "dotted", "dashed"],
+        examples: [
+            "solid",
+            "dotted",
+            "dashed",
+            "solid none",
+            "none none solid none",
+        ],
         type: "string",
-        default: "",
+        default: ""
     },
     borderWidth: {
         type: "string",
-        default: "",
+        default: ""
     },
     color: {
         default: "",
         format: "color",
-        type: "string",
+        type: "string"
     },
     contentIconPath: {
         description: "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-        oneOf: [
+        anyOf: [
             {
                 default: "",
                 format: "uri",
-                type: "string",
+                type: "string"
             },
             {
                 default: "",
-                type: "string",
+                type: "string"
             },
-        ],
+        ]
     },
     contentText: {
         description: "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
         default: "",
-        type: "string",
+        type: "string"
     },
     cursor: {
+        anyOf: [
+            {
+                enum: [
+                    "alias",
+                    "all-scroll",
+                    "auto",
+                    "cell",
+                    "context-menu",
+                    "col-resize",
+                    "copy",
+                    "crosshair",
+                    "default",
+                    "e-resize",
+                    "ew-resize",
+                    "grab",
+                    "grabbing",
+                    "help",
+                    "move",
+                    "n-resize",
+                    "ne-resize",
+                    "nesw-resize",
+                    "ns-resize",
+                    "nw-resize",
+                    "nwse-resize",
+                    "no-drop",
+                    "none",
+                    "not-allowed",
+                    "pointer",
+                    "progress",
+                    "row-resize",
+                    "s-resize",
+                    "se-resize",
+                    "sw-resize",
+                    "text",
+                    "vertical-text",
+                    "w-resize",
+                    "wait",
+                    "zoom-in",
+                    "zoom-out",
+                    "initial",
+                    "inherit",
+                ]
+            },
+            {
+                format: "uri"
+            },
+        ],
         default: "",
-        type: "string",
+        description: "Specifies the mouse cursor to be displayed when pointing over a decoration.",
+        type: "string"
     },
     filterFileRegex: {
-        type: "string",
+        type: "string"
     },
     filterLanguageRegex: {
-        type: "string",
+        type: "string"
     },
     fontStyle: {
         default: "",
-        examples: [
-          "normal", "italic", "oblique"
-        ],
+        enum: ["normal", "italic", "oblique", "unset", ""],
         type: "string"
     },
     fontWeight: {
@@ -99,13 +151,13 @@ const prop = {
             "medium",
         ],
         type: "string",
-        default: "500",
+        default: "500"
     },
     gutterIconPath: {
         type: "string",
         default: "",
         format: "uri",
-        description: "An absolute path or an URI to an image to be rendered in the gutter.",
+        description: "An absolute path or an URI to an image to be rendered in the gutter."
     },
     gutterIconSize: {
         type: "string",
@@ -115,16 +167,16 @@ const prop = {
             { pattern: "\\d+(\\.\\d+)%" },
             {
                 enum: [
-                    'auto',
-                    'contain',
-                    'cover'
+                    "auto",
+                    "contain",
+                    "cover",
                 ]
-            }
+            },
         ]
     },
     height: {
         type: "string",
-        default: "",
+        default: ""
     },
     isWholeLine: {
         type: "boolean",
@@ -133,19 +185,21 @@ const prop = {
     },
     letterSpacing: {
         type: "string",
-        default: "",
+        default: ""
     },
     margin: {
         type: "string",
-        default: "",
+        default: ""
     },
     opacity: {
-        type: "string",
-        default: "",
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+        default: 1
     },
     outline: {
         type: "string",
-        default: "",
+        default: ""
     },
     outlineColor: {
         type: "string",
@@ -167,13 +221,13 @@ const prop = {
         default: "",
         format: "color",
         type: "string",
-        description: "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations.",
+        description: "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
     },
     overviewRulerLane: {
         description: "The position in the overview ruler where the decoration should be rendered.",
         enum: ["center", "full", "left", "right"],
         type: "string",
-        default: "center",
+        default: "center"
     },
     rangeBehavior: {
         enum: [1, 2, 3, 4],
@@ -188,13 +242,15 @@ const prop = {
     },
     width: {
         default: "",
-        type: "string",
+        type: "string"
     },
 };
 const propList = {
     /**
     * Decoration schema's properties list. Used for `highlight.regexes` and
     * `highlight.decorations` properties
+    *
+    * @see https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions
     */
     get decorationRenderOptions() {
         return {
@@ -227,9 +283,12 @@ const propList = {
             overviewRulerColor: prop.overviewRulerColor,
             overviewRulerLane: prop.overviewRulerLane,
             rangeBehavior: prop.rangeBehavior,
-            textDecoration: prop.textDecoration,
+            textDecoration: prop.textDecoration
         };
     },
+    /**
+     * @see https://code.visualstudio.com/api/references/vscode-api#ThemableDecorationRenderOptions
+     */
     get themableDecorationRenderOptions() {
         return {
             after: schemaObj.after,
@@ -254,9 +313,12 @@ const propList = {
             outlineStyle: prop.outlineStyle,
             outlineWidth: prop.outlineWidth,
             overviewRulerColor: prop.overviewRulerColor,
-            textDecoration: prop.textDecoration,
+            textDecoration: prop.textDecoration
         };
     },
+    /**
+     * @see https://code.visualstudio.com/api/references/vscode-api#ThemableDecorationAttachmentRenderOptions
+     */
     get themableDecorationAttachmentRenderOptions() {
         return {
             backgroundColor: prop.backgroundColor,
@@ -270,7 +332,7 @@ const propList = {
             height: prop.height,
             margin: prop.margin,
             textDecoration: prop.textDecoration,
-            width: prop.width,
+            width: prop.width
         };
     },
 };
@@ -283,7 +345,7 @@ const schemaObj = {
             type: "object",
             description: "Object mapping regexes to an array of decorations to apply to the capturing groups",
             default: {},
-            properties: propList.decorationRenderOptions,
+            properties: propList.decorationRenderOptions
         };
     },
     get regexFlags() {
@@ -325,7 +387,7 @@ const schemaObj = {
             default: {},
             properties: propList.themableDecorationRenderOptions
         };
-    }
+    },
 };
 const configuration = {
     type: "object",
@@ -335,7 +397,7 @@ const configuration = {
             type: "object",
             description: "Default decorations from which all others inherit from",
             default: { rangeBehavior: 3 },
-            properties: propList.decorationRenderOptions,
+            properties: propList.decorationRenderOptions
         },
         "highlight.regexes": {
             type: "object",
@@ -351,18 +413,18 @@ const configuration = {
                         items: {
                             type: "object",
                             properties: propList.decorationRenderOptions,
-                            default: {},
-                        },
-                    },
-                },
-            },
+                            default: {}
+                        }
+                    }
+                }
+            }
         },
         "highlight.regexFlags": schemaObj.regexFlags,
         "highlight.maxMatches": {
             type: "number",
             description: "Maximum number of matches to decorate per regex, in order not to crash the app with accidental cathastropic regexes",
-            default: 250,
-        },
+            default: 250
+        }
     },
 };
 const indentLevel = 2;
@@ -373,8 +435,9 @@ class ConfigurationGenerator {
     }
     toString() {
         const output = JSON.stringify(configuration, null, this.indentLevel);
-        if (!output)
-            throw new Error('Generating schema failed.');
+        if (!output) {
+            throw new Error("Generating schema failed.");
+        }
         return output;
     }
     toJSON() {

--- a/schemas/configuration.ts
+++ b/schemas/configuration.ts
@@ -40,7 +40,7 @@ const prop: SchemaPropertyList = {
     type: "string",
   },
   borderStyle: {
-    enum: ["solid", "dotted", "dashed"],
+    examples: ["solid", "dotted", "dashed"],
     type: "string",
     default: "",
   },

--- a/schemas/configuration.ts
+++ b/schemas/configuration.ts
@@ -1,0 +1,412 @@
+/**
+ * Creation/composition of extension configuration related JSON objects, due to
+ * JSON schema support being "odd" in regards to VSCode settings contributions
+ */
+
+import * as Schema from "json-schema";
+
+interface SchemaPropertyList {
+  [key: string]: Schema.JSONSchema6Definition;
+}
+
+const prop: SchemaPropertyList = {
+  backgroundColor: {
+    default: "",
+    format: "color",
+    type: "string"
+  },
+  border: {
+    default: "",
+    type: "string",
+  },
+  borderColor: {
+    default: "#FFFFFF22",
+    format: "color",
+    type: "string",
+  },
+  borderRadius: {
+    default: "4px",
+    examples: [
+      "2px",
+      "0.25em",
+      "2px 0px",
+      "0px 0px 0px 4px",
+      "10px 40px / 20px 60px",
+    ],
+    type: "string",
+  },
+  borderSpacing: {
+    default: "2px",
+    type: "string",
+  },
+  borderStyle: {
+    enum: ["solid", "dotted", "dashed"],
+    type: "string",
+    default: "",
+  },
+  borderWidth: {
+    type: "string",
+    default: "",
+  },
+  color: {
+    default: "",
+    format: "color",
+    type: "string",
+  },
+  contentIconPath: {
+    description: "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+    oneOf: [
+      {
+        default: "",
+        format: "uri",
+        type: "string",
+      },
+      {
+        default: "",
+        type: "string",
+      },
+    ],
+  },
+  contentText: {
+    description: "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+    default: "",
+    type: "string",
+  },
+  cursor: {
+    default: "",
+    type: "string",
+  },
+  filterFileRegex: {
+    type: "string",
+  },
+  filterLanguageRegex: {
+    type: "string",
+  },
+  fontStyle: {
+    default: "",
+    enum: ["normal", "italic", "oblique", ""],
+    type: "string",
+  },
+  fontWeight: {
+    enum: [
+      "100",
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "700",
+      "800",
+      "900",
+      "bold",
+      "medium",
+    ],
+    type: "string",
+    default: "500",
+  },
+  gutterIconPath: {
+    type: "string",
+    default: "",
+    format: "uri",
+    description: "An absolute path or an URI to an image to be rendered in the gutter.",
+  },
+  gutterIconSize: {
+    type: "string",
+    default: "",
+    description: "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+    oneOf: [
+      { pattern: "\\d+(\\.\\d+)%" },
+      {
+        enum: [
+          'auto',
+          'contain',
+          'cover'
+        ]
+      }
+    ]
+  },
+  height: {
+    type: "string",
+    default: "",
+  },
+  isWholeLine: {
+    type: "boolean",
+    default: false,
+    description: "Should the decoration be rendered also on the whitespace after the line text."
+  },
+  letterSpacing: {
+    type: "string",
+    default: "",
+  },
+  margin: {
+    type: "string",
+    default: "",
+  },
+  opacity: {
+    type: "string",
+    default: "",
+  },
+  outline: {
+    type: "string",
+    default: "",
+  },
+  outlineColor: {
+    type: "string",
+    default: "",
+    format: "color",
+    description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+  },
+  outlineStyle: {
+    type: "string",
+    default: "",
+    description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+  },
+  outlineWidth: {
+    type: "string",
+    default: "",
+    description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+  },
+  overviewRulerColor: {
+    default: "",
+    format: "color",
+    type: "string",
+    description: "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations.",
+  },
+  overviewRulerLane: {
+    description: "The position in the overview ruler where the decoration should be rendered.",
+    enum: ["center", "full", "left", "right"],
+    type: "string",
+    default: "center",
+  },
+  rangeBehavior: {
+    enum: [1, 2, 3, 4],
+    type: "number",
+    default: 3,
+    description: "Customize the growing behavior of the decoration when edits occur at the edges of the decoration's range."
+  },
+  textDecoration: {
+    default: "",
+    type: "string",
+    description: "CSS styling property that will be applied to text enclosed by a decoration."
+  },
+  width: {
+    default: "",
+    type: "string",
+  },
+};
+
+const propList: {[key: string]: SchemaPropertyList} = {
+  /**
+  * Decoration schema's properties list. Used for `highlight.regexes` and
+  * `highlight.decorations` properties
+  */
+  get decorationRenderOptions() {
+    return {
+      after: schemaObj.after,
+      backgroundColor: prop.backgroundColor,
+      before: schemaObj.before,
+      border: prop.border,
+      borderColor: prop.borderColor,
+      borderRadius: prop.borderRadius,
+      borderSpacing: prop.borderSpacing,
+      borderStyle: prop.borderStyle,
+      borderWidth: prop.borderWidth,
+      color: prop.color,
+      contentIconPath: prop.contentIconPath,
+      contentText: prop.contentText,
+      cursor: prop.cursor,
+      dark: schemaObj.dark,
+      fontStyle: prop.fontStyle,
+      fontWeight: prop.fontWeight,
+      gutterIconPath: prop.gutterIconPath,
+      gutterIconSize: prop.gutterIconSize,
+      isWholeLine: prop.isWholeLine,
+      letterSpacing: prop.letterSpacing,
+      light: schemaObj.light,
+      opacity: prop.opacity,
+      outline: prop.outline,
+      outlineColor: prop.outlineColor,
+      outlineStyle: prop.outlineStyle,
+      outlineWidth: prop.outlineWidth,
+      overviewRulerColor: prop.overviewRulerColor,
+      overviewRulerLane: prop.overviewRulerLane,
+      rangeBehavior: prop.rangeBehavior,
+      textDecoration: prop.textDecoration,
+    };
+  },
+
+  get themableDecorationRenderOptions() {
+    return {
+      after: schemaObj.after,
+      backgroundColor: prop.backgroundColor,
+      before: schemaObj.before,
+      border: prop.border,
+      borderColor: prop.borderColor,
+      borderRadius: prop.borderRadius,
+      borderSpacing: prop.borderSpacing,
+      borderStyle: prop.borderStyle,
+      borderWidth: prop.borderWidth,
+      color: prop.color,
+      cursor: prop.cursor,
+      fontStyle: prop.fontStyle,
+      fontWeight: prop.fontWeight,
+      gutterIconPath: prop.gutterIconPath,
+      gutterIconSize: prop.gutterIconSize,
+      letterSpacing: prop.letterSpacing,
+      opacity: prop.opacity,
+      outline: prop.outline,
+      outlineColor: prop.outlineColor,
+      outlineStyle: prop.outlineStyle,
+      outlineWidth: prop.outlineWidth,
+      overviewRulerColor: prop.overviewRulerColor,
+      textDecoration: prop.textDecoration,
+    };
+  },
+
+  get themableDecorationAttachmentRenderOptions() {
+    return {
+      backgroundColor: prop.backgroundColor,
+      border: prop.border,
+      borderColor: prop.borderColor,
+      color: prop.color,
+      contentIconPath: prop.contentIconPath,
+      contentText: prop.contentText,
+      fontStyle: prop.fontStyle,
+      fontWeight: prop.fontWeight,
+      height: prop.height,
+      margin: prop.margin,
+      textDecoration: prop.textDecoration,
+      width: prop.width,
+    };
+  },
+};
+
+const schemaObj = {
+  /**
+   * Decoration schema. Used for `highlight.regexes` and `highlight.decorations`
+   */
+  get decoration(): Schema.JSONSchema6 {
+    return {
+      type: "object",
+      description:
+        "Object mapping regexes to an array of decorations to apply to the capturing groups",
+      default: {},
+      properties: propList.decorationRenderOptions,
+    };
+  },
+
+  get regexFlags(): Schema.JSONSchema6 {
+    return {
+      type: "string",
+      description: "Flags used when building the regexes",
+      pattern: "^((?:([gmi])(?!.*\\2))*)$",
+      default: "gi"
+    };
+  },
+
+  get after(): Schema.JSONSchema6 {
+    return {
+      type: "object",
+      default: {},
+      description: "Defines the rendering options of the attachment that is inserted before the decorated text.",
+      properties: propList.themableDecorationAttachmentRenderOptions
+    };
+  },
+
+  get before(): Schema.JSONSchema6 {
+    return {
+      type: "object",
+      default: {},
+      description: "Defines the rendering options of the attachment that is inserted before the decorated text.",
+      properties: propList.themableDecorationAttachmentRenderOptions
+    };
+  },
+
+  get dark(): Schema.JSONSchema6 {
+    return {
+      type: "object",
+      description: "Overwrite options for dark themes.",
+      default: {},
+      properties: propList.themableDecorationRenderOptions
+    };
+  },
+
+  get light(): Schema.JSONSchema6 {
+    return {
+      type: "object",
+      description: "Overwrite options for light themes.",
+      default: {},
+      properties: propList.themableDecorationRenderOptions
+    };
+  }
+};
+
+const configuration: Schema.JSONSchema6 = {
+  type: "object",
+  title: "Highlight - Configuration",
+  properties: {
+    "highlight.decorations": {
+      type: "object",
+      description: "Default decorations from which all others inherit from",
+      default: { rangeBehavior: 3 },
+      properties: propList.decorationRenderOptions,
+    },
+    "highlight.regexes": {
+      type: "object",
+      description:
+        "Object mapping regexes to an array of decorations to apply to the capturing groups",
+      default: {},
+      additionalProperties: {
+        properties: {
+          filterFileRegex: prop.filterFileRegex,
+          filterLanguageRegex: prop.filterFileRegex,
+          regexFlags: schemaObj.regexFlags,
+          decorations: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: propList.decorationRenderOptions,
+              default: {},
+            },
+          },
+        },
+      },
+    },
+    "highlight.regexFlags": schemaObj.regexFlags,
+    "highlight.maxMatches": {
+      type: "number",
+      description:
+        "Maximum number of matches to decorate per regex, in order not to crash the app with accidental cathastropic regexes",
+      default: 250,
+    },
+  },
+};
+
+const indentLevel: number = 2;
+
+class ConfigurationGenerator {
+  indentLevel: number = indentLevel;
+  configuration: Schema.JSONSchema6;
+
+  toString(): string
+  {
+    const output = JSON.stringify(configuration, null, this.indentLevel);
+    if(!output)
+      throw new Error('Generating schema failed.');
+
+    return output;
+  }
+
+  toJSON(): JSON
+  {
+    // Not sure why I had to do this
+    return JSON.parse(JSON.stringify(this.configuration));
+  }
+
+  constructor(configuration: Schema.JSONSchema6)
+  {
+    this.configuration = configuration;
+  }
+}
+
+export default new ConfigurationGenerator(configuration);

--- a/schemas/configuration.ts
+++ b/schemas/configuration.ts
@@ -17,12 +17,12 @@ const prop: SchemaPropertyList = {
   },
   border: {
     default: "",
-    type: "string",
+    type: "string"
   },
   borderColor: {
     default: "#FFFFFF22",
     format: "color",
-    type: "string",
+    type: "string"
   },
   borderRadius: {
     default: "4px",
@@ -33,59 +33,116 @@ const prop: SchemaPropertyList = {
       "0px 0px 0px 4px",
       "10px 40px / 20px 60px",
     ],
-    type: "string",
+    type: "string"
   },
   borderSpacing: {
     default: "2px",
-    type: "string",
+    type: "string"
   },
   borderStyle: {
-    examples: ["solid", "dotted", "dashed"],
+    examples: [
+      "solid",
+      "dotted",
+      "dashed",
+      "solid none",
+      "none none solid none",
+    ],
     type: "string",
-    default: "",
+    default: ""
   },
   borderWidth: {
     type: "string",
-    default: "",
+    default: ""
   },
   color: {
     default: "",
     format: "color",
-    type: "string",
+    type: "string"
   },
   contentIconPath: {
-    description: "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
-    oneOf: [
+    description:
+      "An absolute path or an URI to an image to be rendered in the attachment. Either an icon or a text can be shown, but not both.",
+    anyOf: [
       {
         default: "",
         format: "uri",
-        type: "string",
+        type: "string"
       },
       {
         default: "",
-        type: "string",
+        type: "string"
       },
-    ],
+    ]
   },
   contentText: {
-    description: "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
+    description:
+      "Defines a text content that is shown in the attachment. Either an icon or a text can be shown, but not both.",
     default: "",
-    type: "string",
+    type: "string"
   },
   cursor: {
+    anyOf: [
+      {
+        enum: [
+          "alias",
+          "all-scroll",
+          "auto",
+          "cell",
+          "context-menu",
+          "col-resize",
+          "copy",
+          "crosshair",
+          "default",
+          "e-resize",
+          "ew-resize",
+          "grab",
+          "grabbing",
+          "help",
+          "move",
+          "n-resize",
+          "ne-resize",
+          "nesw-resize",
+          "ns-resize",
+          "nw-resize",
+          "nwse-resize",
+          "no-drop",
+          "none",
+          "not-allowed",
+          "pointer",
+          "progress",
+          "row-resize",
+          "s-resize",
+          "se-resize",
+          "sw-resize",
+          "text",
+          "vertical-text",
+          "w-resize",
+          "wait",
+          "zoom-in",
+          "zoom-out",
+          "initial",
+          "inherit",
+        ]
+      },
+      {
+        format: "uri"
+      },
+    ],
     default: "",
-    type: "string",
+    description:
+      "Specifies the mouse cursor to be displayed when pointing over a decoration.",
+    type: "string"
   },
   filterFileRegex: {
-    type: "string",
+    type: "string"
   },
   filterLanguageRegex: {
-    type: "string",
+    type: "string"
   },
   fontStyle: {
     default: "",
-    enum: ["normal", "italic", "oblique", ""],
-    type: "string",
+    enum: ["normal", "italic", "oblique", "unset", ""],
+    type: "string"
   },
   fontWeight: {
     enum: [
@@ -102,103 +159,117 @@ const prop: SchemaPropertyList = {
       "medium",
     ],
     type: "string",
-    default: "500",
+    default: "500"
   },
   gutterIconPath: {
     type: "string",
     default: "",
     format: "uri",
-    description: "An absolute path or an URI to an image to be rendered in the gutter.",
+    description:
+      "An absolute path or an URI to an image to be rendered in the gutter."
   },
   gutterIconSize: {
     type: "string",
     default: "",
-    description: "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
+    description:
+      "Specifies the size of the gutter icon. Available values are 'auto', 'contain', 'cover' and any percentage value. For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx",
     oneOf: [
       { pattern: "\\d+(\\.\\d+)%" },
       {
         enum: [
-          'auto',
-          'contain',
-          'cover'
+          "auto",
+          "contain",
+          "cover",
         ]
-      }
+      },
     ]
   },
   height: {
     type: "string",
-    default: "",
+    default: ""
   },
   isWholeLine: {
     type: "boolean",
     default: false,
-    description: "Should the decoration be rendered also on the whitespace after the line text."
+    description:
+      "Should the decoration be rendered also on the whitespace after the line text."
   },
   letterSpacing: {
     type: "string",
-    default: "",
+    default: ""
   },
   margin: {
     type: "string",
-    default: "",
+    default: ""
   },
   opacity: {
-    type: "string",
-    default: "",
+    type: "number",
+    minimum: 0,
+    maximum: 1,
+    default: 1
   },
   outline: {
     type: "string",
-    default: "",
+    default: ""
   },
   outlineColor: {
     type: "string",
     default: "",
     format: "color",
-    description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+    description:
+      "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
   },
   outlineStyle: {
     type: "string",
     default: "",
-    description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+    description:
+      "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
   },
   outlineWidth: {
     type: "string",
     default: "",
-    description: "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
+    description:
+      "Applied to text enclosed by a decoration. Better use 'outline' for setting one or more of the individual outline properties."
   },
   overviewRulerColor: {
     default: "",
     format: "color",
     type: "string",
-    description: "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations.",
+    description:
+      "The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations."
   },
   overviewRulerLane: {
-    description: "The position in the overview ruler where the decoration should be rendered.",
+    description:
+      "The position in the overview ruler where the decoration should be rendered.",
     enum: ["center", "full", "left", "right"],
     type: "string",
-    default: "center",
+    default: "center"
   },
   rangeBehavior: {
     enum: [1, 2, 3, 4],
     type: "number",
     default: 3,
-    description: "Customize the growing behavior of the decoration when edits occur at the edges of the decoration's range."
+    description:
+      "Customize the growing behavior of the decoration when edits occur at the edges of the decoration's range."
   },
   textDecoration: {
     default: "",
     type: "string",
-    description: "CSS styling property that will be applied to text enclosed by a decoration."
+    description:
+      "CSS styling property that will be applied to text enclosed by a decoration."
   },
   width: {
     default: "",
-    type: "string",
+    type: "string"
   },
 };
 
-const propList: {[key: string]: SchemaPropertyList} = {
+const propList: { [key: string]: SchemaPropertyList } = {
   /**
   * Decoration schema's properties list. Used for `highlight.regexes` and
   * `highlight.decorations` properties
+  *
+  * @see https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions
   */
   get decorationRenderOptions() {
     return {
@@ -231,10 +302,13 @@ const propList: {[key: string]: SchemaPropertyList} = {
       overviewRulerColor: prop.overviewRulerColor,
       overviewRulerLane: prop.overviewRulerLane,
       rangeBehavior: prop.rangeBehavior,
-      textDecoration: prop.textDecoration,
+      textDecoration: prop.textDecoration
     };
   },
 
+  /**
+   * @see https://code.visualstudio.com/api/references/vscode-api#ThemableDecorationRenderOptions
+   */
   get themableDecorationRenderOptions() {
     return {
       after: schemaObj.after,
@@ -259,10 +333,13 @@ const propList: {[key: string]: SchemaPropertyList} = {
       outlineStyle: prop.outlineStyle,
       outlineWidth: prop.outlineWidth,
       overviewRulerColor: prop.overviewRulerColor,
-      textDecoration: prop.textDecoration,
+      textDecoration: prop.textDecoration
     };
   },
 
+  /**
+   * @see https://code.visualstudio.com/api/references/vscode-api#ThemableDecorationAttachmentRenderOptions
+   */
   get themableDecorationAttachmentRenderOptions() {
     return {
       backgroundColor: prop.backgroundColor,
@@ -276,7 +353,7 @@ const propList: {[key: string]: SchemaPropertyList} = {
       height: prop.height,
       margin: prop.margin,
       textDecoration: prop.textDecoration,
-      width: prop.width,
+      width: prop.width
     };
   },
 };
@@ -291,7 +368,7 @@ const schemaObj = {
       description:
         "Object mapping regexes to an array of decorations to apply to the capturing groups",
       default: {},
-      properties: propList.decorationRenderOptions,
+      properties: propList.decorationRenderOptions
     };
   },
 
@@ -308,7 +385,8 @@ const schemaObj = {
     return {
       type: "object",
       default: {},
-      description: "Defines the rendering options of the attachment that is inserted before the decorated text.",
+      description:
+        "Defines the rendering options of the attachment that is inserted before the decorated text.",
       properties: propList.themableDecorationAttachmentRenderOptions
     };
   },
@@ -317,7 +395,8 @@ const schemaObj = {
     return {
       type: "object",
       default: {},
-      description: "Defines the rendering options of the attachment that is inserted before the decorated text.",
+      description:
+        "Defines the rendering options of the attachment that is inserted before the decorated text.",
       properties: propList.themableDecorationAttachmentRenderOptions
     };
   },
@@ -338,7 +417,7 @@ const schemaObj = {
       default: {},
       properties: propList.themableDecorationRenderOptions
     };
-  }
+  },
 };
 
 const configuration: Schema.JSONSchema6 = {
@@ -349,7 +428,7 @@ const configuration: Schema.JSONSchema6 = {
       type: "object",
       description: "Default decorations from which all others inherit from",
       default: { rangeBehavior: 3 },
-      properties: propList.decorationRenderOptions,
+      properties: propList.decorationRenderOptions
     },
     "highlight.regexes": {
       type: "object",
@@ -366,19 +445,19 @@ const configuration: Schema.JSONSchema6 = {
             items: {
               type: "object",
               properties: propList.decorationRenderOptions,
-              default: {},
-            },
-          },
-        },
-      },
+              default: {}
+            }
+          }
+        }
+      }
     },
     "highlight.regexFlags": schemaObj.regexFlags,
     "highlight.maxMatches": {
       type: "number",
       description:
         "Maximum number of matches to decorate per regex, in order not to crash the app with accidental cathastropic regexes",
-      default: 250,
-    },
+      default: 250
+    }
   },
 };
 
@@ -388,23 +467,21 @@ class ConfigurationGenerator {
   indentLevel: number = indentLevel;
   configuration: Schema.JSONSchema6;
 
-  toString(): string
-  {
+  toString(): string {
     const output = JSON.stringify(configuration, null, this.indentLevel);
-    if(!output)
-      throw new Error('Generating schema failed.');
+    if (!output) {
+      throw new Error("Generating schema failed.");
+    }
 
     return output;
   }
 
-  toJSON(): JSON
-  {
+  toJSON(): JSON {
     // Not sure why I had to do this
     return JSON.parse(JSON.stringify(this.configuration));
   }
 
-  constructor(configuration: Schema.JSONSchema6)
-  {
+  constructor(configuration: Schema.JSONSchema6) {
     this.configuration = configuration;
   }
 }

--- a/schemas/updatePackageConfiguration.js
+++ b/schemas/updatePackageConfiguration.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// Test flag, setting to false writed to another file in same dir for comparison
+const doUpdateOriginalPackage = true;
+
+const fs = require('fs');
+
+const basePath = __dirname + '/../',
+      packagePath = basePath + 'package.json',
+      testPackagePath = 'package.updated.json',
+      configurationPath = __dirname + '/configuration.js';
+
+// Load new schema
+const configuration = require(configurationPath).default
+if(!configuration)
+  throw new Error("Failed to load configuration script");
+
+// Load package json data
+const packageData = require(packagePath);
+if(!packageData.contributes.configuration)
+  throw new Error("Failed to load package.json");
+
+// Update imported package object
+packageData.contributes.configuration = configuration.toJSON();
+
+// Update to package.json or write to test file
+const writePath = doUpdateOriginalPackage ? packagePath : testPackagePath;
+console.log(`Writing to path '${writePath}'`)
+fs.writeFile(
+  writePath,
+  JSON.stringify(packageData, null, 2),
+  (err) => {
+    if (err)
+      throw err;
+    else
+      console.log(`Wrote to path '${writePath}' successfully.`);
+  },
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "exclude": [
     "node_modules",
-    ".vscode-test"
+    ".vscode-test",
+    "schemas"
   ]
 }


### PR DESCRIPTION
Full schema description of extension configuration using the [VSCode API reference](https://code.visualstudio.com/api/references/vscode-api).

- Schema format properties for URI paths and colors

- Descriptions for properties with unique descriptions on the API reference

- Enumerations and pattern schema properties where possible, but not over restricting. e.g. fontWeight is enum, regexFlags is pattered, but you can still do tricks like `; margin-left: 1.5em;` on most decoration properties

![image](https://user-images.githubusercontent.com/13393582/85345710-12bb6d80-b4a8-11ea-9ae2-570ba9124139.png)

Previous attemts to implement with `$ref` for brevity failed (vscode seems to have issues with using them for extension configuration based on some previous repo issues), so I wrote a script to generate and update package.json. The configuration description is in typescript and uses the json-schema package, its excluded in tsconfig for now to defer adding any dependencies for now (the javascript output works without it, though).