### PR TITLE
Decoration override by Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ If you want to have different regex flags for different regexes, or if you want 
 }
 ```
 
+If you want to set decorations for different themes you can use:
+
+```js
+"highlight.regexes": {
+  "(//TODO)(:)": {
+    "regexFlags": "g",
+    "filterLanguageRegex": "markdown",
+    "filterFileRegex": ".*\\.ext",
+    "decorations": [ // Decoration options for not specified themes
+      { "color": "yellow" },
+      { "color": "red" }
+    ],
+    "[One Dark Pro]": {
+      "decorations": [
+        { "color": "green" },
+        { "color": "tomato" }
+      ]
+    }
+  }
+}
+```
+
 Decoration values can also include placeholders like `$1` or `$2` that will be replaced with the content of the respective capturing group, enabling complex use cases like CSS colors highlighting.
 
 All the supported decoration options are defined [here](https://code.visualstudio.com/docs/extensionAPI/vscode-api#DecorationRenderOptions).

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,11 @@ const Config = {
 
     return vscode.workspace.getConfiguration ().get ( extension ) as any;
 
+  },
+
+  colorTheme() {
+    const theme = vscode.workspace.getConfiguration ().get ( "workbench.colorTheme" ) || "Default";
+    return `[${theme}]`;
   }
 
 };

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -24,10 +24,12 @@ const Decorator = {
   /* CONFIG */
 
   config: undefined,
+  colorTheme: undefined,
 
   initConfig () {
 
     Decorator.config = Config.get ();
+    Decorator.colorTheme = Config.colorTheme ();
 
   },
 
@@ -70,8 +72,11 @@ const Decorator = {
     const decorations = Decorator.config.decorations,
           types = Decorator.regexesStrs.map ( reStr => {
 
-            const options = Decorator.config.regexes[reStr],
-                  reDecorations = _.castArray ( options.decorations || options );
+            const options = Decorator.config.regexes[reStr];
+            let themeDecorations = undefined;
+            const themeOptions = options[Decorator.colorTheme];
+            if (themeOptions) { themeDecorations = themeOptions.decorations; }
+            const reDecorations = _.castArray ( themeDecorations || options.decorations || options );
 
             return reDecorations.map ( options => {
 


### PR DESCRIPTION
You can specify decorations by Theme with the following setting

```js
"highlight.regexes": {
  "(//TODO)(:)": {
    "regexFlags": "g",
    "filterLanguageRegex": "markdown",
    "filterFileRegex": ".*\\.ext",
    "decorations": [ // Decoration options for not specified themes
      { "color": "yellow" },
      { "color": "red" }
    ],
    "[One Dark Pro]": {
      "decorations": [
        { "color": "green" },
        { "color": "tomato" }
      ]
    }
  }
}
```