### PR TITLE
Added force decorate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -526,7 +526,7 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "webpack --mode production",
+    "vscode:prepublish": "rm -rf out && webpack --mode production",
     "publish": "vsce publish && npm publish",
     "compile": "webpack --mode development",
     "compile:watch": "webpack --mode development --watch",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "displayName": "Highlight",
   "description": "Advanced text highlighter based on regexes. Useful for todos, annotations, colors etc.",
   "icon": "resources/logo-128x128.png",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "main": "out/extension.js",
   "publisher": "fabiospampinato",
   "activationEvents": [
-    "*"
+    "*",
+		"onCommand:vscode-highlight.forceDecorate"
   ],
   "contributes": {
     "configuration": {
@@ -509,11 +510,23 @@
           "description": "Maximum number of matches to decorate per regex, in order not to crash the app with accidental cathastropic regexes",
           "default": 250
         }
-      }
+      },
+      "commands": [
+        {
+          "command": "vscode-highlight.forceDecorate",
+          "title": "Force Decorate"
+        }
+      ],
+      "keybindings": [
+        {
+          "command": "vscode-highlight.forceDecorate",
+          "key": "ctrl+alt+t"
+        }
+      ]
     }
   },
   "scripts": {
-    "vscode:prepublish": "rm -rf out && webpack --mode production",
+    "vscode:prepublish": "webpack --mode production",
     "publish": "vsce publish && npm publish",
     "compile": "webpack --mode development",
     "compile:watch": "webpack --mode development --watch",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,14 @@ function activate ( context: vscode.ExtensionContext ) {
 
   Decorator.decorate ();
 
+	vscode.commands.registerCommand('vscode-highlight.forceDecorate', () => 
+  {
+    vscode.window.visibleTextEditors.forEach(editor => 
+    {
+      Decorator.decorate ( editor, true );
+    });
+  });
+
 }
 
 /* EXPORT */


### PR DESCRIPTION
Added a forceDecorate command to the extension.ts and package.json. The command can be called from a 3rd part extension to apply the decorate function to all visible editors. This is useful for when the visible editors change, such as scrolling through a python notebook. 