### PR TITLE
Readme: Improve color highlighting example by using `contrast-color()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,7 +221,7 @@ The following is the configuration I'm currently using for highlighting colors, 
         "borderStyle": "solid",
         "borderColor": "$1",
         "backgroundColor": "$1",
-        "color": "#ffffff"
+        "color": "contrast-color(color-mix(in oklab, $1, black 23%))"
       }
     ]
   }


### PR DESCRIPTION
Using the recent CSS function [`contrast-color()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/contrast-color), the readability can be improved by automatically using black text on lighter colors. Note that this will probably not work on outdated VSCode installations (The current chromium version of VSCode is barely enough to support the feature).

The `color-mix()` is mostly a matter of preferences, but I included it so that anyone can tweak the threshold.

| Before | After |
|----------|--------|
| <img width="903" height="580" alt="image" src="https://github.com/user-attachments/assets/63b042bc-ada6-4603-9bd8-c79854641b69" /> | <img width="896" height="573" alt="image" src="https://github.com/user-attachments/assets/d1c697ef-4d61-475c-affa-7edd32447c3e" />      |